### PR TITLE
close #46

### DIFF
--- a/_posts/2022-12-28-accuracy.md
+++ b/_posts/2022-12-28-accuracy.md
@@ -1,6 +1,6 @@
 ---
 title: Accuracy
-tags: reliable, usable
+tags: reliable usable
 related: correctness, preciseness
 permalink: /qualities/accuracy
 ---

--- a/_posts/2022-12-28-preciseness.md
+++ b/_posts/2022-12-28-preciseness.md
@@ -1,6 +1,6 @@
 ---
 title: Preciseness
-tags: reliable, usable
+tags: reliable usable
 related: correctness, accuracy
 permalink: /qualities/preciseness
 ---


### PR DESCRIPTION
Quick explanation: The duplicate was there due to the fact that in two quality-posts, the tags were written with a comma (tags: reliable, xyz) instead of just tags: reliable xyz. This created "reliable," as its own tag, which is fixed now because I removed the commas