### PR TITLE
fix citation

### DIFF
--- a/_articles/02-quality-models.md
+++ b/_articles/02-quality-models.md
@@ -25,7 +25,7 @@ Quality models define a _common language_ for terms related to product, system a
 
 ### A Bit of History
 
-In 1976, Barry Boehm and colleagues published [their quality model](/references/#boehm-model), including inner qualities like _structuredness_ and _legibility_. Have a look at the original paper, it is a nice example of _historical typesetting_, some graphs look like drawn with a ballpen :-)
+In 1976, Barry Boehm and colleagues published [their quality model](/references/#boehm1976quantitative), including inner qualities like _structuredness_ and _legibility_. Have a look at the original paper, it is a nice example of _historical typesetting_, some graphs look like drawn with a ballpen :-)
 
 In 1977, McCall suggested to model quality as a hierarchy of terms, whose first level consists of _Operation, Revision_ and _Transition_. To revision he counted e.g. Maintainbility, Flexibility and Testability.
 
@@ -52,8 +52,8 @@ I also liked quality features of the VOLERE Requirements Template, which, howeve
 | Bass et. al | 2022 | One level, see [this article](/articles/sei-quality-model). Practical, with a few rough edges. | 10 |
 | ISO-25010, draft 2022 | 2022 | Proposal to add safety and change a number of terms and definitions. Still [disputable terminology](/articles/iso-25010-shortcomings), overly complex for day-to-day use.  | 39 |
 
-### Boehm Software Quality Model ([[Boehm+1976]](/references/#boehm-model))
-[Barry Boehm](/references/#boehm-model) supposedly was the first to propose a hierarchical model of software quality, with three top-level qualities, that are refined on two further levels. 
+### Boehm Software Quality Model ([[Boehm+1976]](/references/#boehm1976quantitative))
+[Barry Boehm](/references/#boehm1976quantitative) supposedly was the first to propose a hierarchical model of software quality, with three top-level qualities, that are refined on two further levels. 
 When looking into details of his model, one will notice that several attributes from level-2 and level-3 are referenced multiple times, making this model more of a graph than a tree.
 In my opinion, this is perfectly realistic, but the later ISO-standards got rid of this pragmatic feature.
 
@@ -109,7 +109,7 @@ Although some of these definitions are quite academic, they provide a nice start
 >A quality attribute (QA) is a measurable or testable property of a system that is used to indicate how well the system satisfies the needs of its stakeholders beyond the basic function of the system. 
 >You can think of a quality attribute as measuring the “utility” of a product along some dimension of interest to a stakeholder.
 >
->[Len Bass et. al, 2022, p. 39](/references/#bass-swa-practice)
+>[Len Bass et. al, 2021, p. 39](/references/#bass2021software)
 
 
 For Bass and his colleagues, quality consists of 10 major properties, depicted in the following overview.
@@ -122,7 +122,7 @@ They differentiate these qualities into two categories:
 >We will focus on two categories of quality attributes. The first category includes those attributes that describe some property of the system at runtime, such as availability, performance, or usability. 
 >The second category includes those that describe some property of the development of the system, such as modifiability, testability, or deployability.
 >
->[Len Bass et. al, 2022, p. 42](/references/#bass-swa-practice)
+>[Len Bass et. al, 2021, p. 42](/references/#bass2021software)
 
 
 For their work, a huge "thank you" goes to Len Bass and his colleagues, for providing an alternative to the ISO-25010 approach. 

--- a/_articles/03-iso-25010-shortcomings.md
+++ b/_articles/03-iso-25010-shortcomings.md
@@ -124,7 +124,7 @@ The recently published arc42 quality model allows exactly that (see [2]).
 
 
 My conclusion so far: A lot of mass, but important nutrients (e.g. conceptual consistency and clarity) are missing.
-These and other problems with ISO 25010 have initially been pointed out by Len Bass et al.[^bass]
+These and other problems with ISO 25010 have initially been pointed out by [Bass+2021](/references/#bass2021software).
 
 
 ### Does the 2022-Draft Improve the Situation?
@@ -162,7 +162,7 @@ In the new version, I consider it positive that:
 
 
 ### Isn't Software made up from Code?
-Although internal structure, legibility and conciseness have been part of previous quality models (Boehm[^boehm] mentioned these qualities in his model from 1978!), the ISO refused (or forgot?) to include such properties in their model.
+Although internal structure, legibility and conciseness have been part of previous quality models ([Boehm+1976](/references/#boehm1976quantitative) mentioned these qualities in his model from 1978!), the ISO refused (or forgot?) to include such properties in their model.
 
 
 In my opinion, development teams are important stakeholders, and structure and readability of code will often be essential goals for them.
@@ -174,10 +174,10 @@ Although one can use the ISO 25010 standard as a checklist for specific quality 
 For example, the arc42 quality model (Q42) consists of just eight key properties, instead of the 35 terms from ISO 25010.
 
 
-Maybe the most serious disadvantage of ISO 25010 is the complete lack of specific examples of how to apply the model to practical, real-world systems. That leaves development teams and other system stakeholders out in the cold. Len Bass et al.[^bass] have proven in their book that such examples can be systematic and useful. [arc42](https://quality.arc42.org) followed suit, providing numerous tagged and cross-referenced examples of quality requirements.
+Maybe the most serious disadvantage of ISO 25010 is the complete lack of specific examples of how to apply the model to practical, real-world systems. That leaves development teams and other system stakeholders out in the cold. [Bass+2021](/references/#bass2021software) have proven in their book that such examples can be systematic and useful. [arc42](https://quality.arc42.org) followed suit, providing numerous tagged and cross-referenced examples of quality requirements.
 
 
-Another potential source of unwanted complexity is the ISO metamodel[^ISO25010], which distinguishes Quality-in-Use, Data Quality, Service Quality and Product Quality.
+Another potential source of unwanted complexity is the ISO metamodel, which distinguishes Quality-in-Use, Data Quality, Service Quality and Product Quality. (The meta-model is part of the official documentation in the “ISO/IEC 2501n Quality Model Division”, explained within the non-public parts of 25010. It refers to additional standards 25011 (IT service quality model), 25012 (Data quality model) and 25019 (Quality-in-use model), cf. [ISO+25011](/references/#iso-25010-2011)).
 In my opinion, this makes the ISO 25010 model overly difficult to digest for real-world projects.
 
 
@@ -205,29 +205,13 @@ Instead of nearly 40 terms at various levels, a few top-level features would be 
 
 
 
-In this respect, Len Bass and Co. have done an outstanding job with their fundamental work [^bass]. They had already invented the concept of "quality scenarios" many years ago.
+In this respect, Len Bass and Co. have done an outstanding job with their fundamental work [Bass+2021](/references/#bass2021software). They had already invented the concept of "quality scenarios" many years ago.
 In their fourth and latest edition of their book, they followed up with a multitude of practical examples.
 You can find a brief overview of their work in [another article](/articles/sei-quality-model).
 
 
 ### Acknowledgements
 Thanx to “m” , Anja Kammer, Daniel Lauxtermann, Joachim Praetorius and Ben Wolf for bug fixing and dramatically improving the quality of this post. Thanx to Eberhard Wolff for encouragements.
-
-
-
-### References
-
-
-[^bass]: Len Bass et. Al: Software Architecture in Practice, Fourth Edition, Addison-Wesley, 2022. 
-
-
-[^boehm]: Boehm, B. W., Brown, H., Lipow,M. (1978) “Quantitative Evaluation of Software Quality,”, TRW Systems and Energy Group, 1978. This source is hard to come by. Their approach is covered in a comparative study of [Software Quality Models](https://enos.itcollege.ee/~nafurs/suvi2019/huvitavat/alternatiivid_FURPSile.pdf).
-
-
-[^iso25010]: The meta-model is part of the official documentation in the “ISO/IEC 2501n Quality Model Division”, explained within the non-public parts of 25010. It refers to additional standards 25011 (IT service quality model), 25012 (Data quality model) and 25019 (Quality-in-use model). 
-
-
-[^Q42]: arc42 Quality Model, online on https://quality.arc42.org
 
 
 

--- a/_articles/04-sei-quality-model.md
+++ b/_articles/04-sei-quality-model.md
@@ -21,7 +21,7 @@ Within their fourth edition, the authors present a modernized approach to softwa
 >A quality attribute (QA) is a measurable or testable property of a system that is used to indicate how well the system satisfies the needs of its stakeholders beyond the basic function of the system. 
 >You can think of a quality attribute as measuring the “utility” of a product along some dimension of interest to a stakeholder.
 >
->[Len Bass et. al, 2022, p. 39](/references/#bass-swa-practice)
+>[Len Bass et. al, 2021, p. 39](/references/#bass2021software)
 
 
 For Bass and his colleagues, quality consists of 10 major properties, depicted in the following overview.
@@ -34,7 +34,7 @@ They differentiate these qualities into two categories:
 >We will focus on two categories of quality attributes. The first category includes those attributes that describe some property of the system at runtime, such as availability, performance, or usability. 
 >The second category includes those that describe some property of the development of the system, such as modifiability, testability, or deployability.
 >
->[Len Bass et. al, 2022, p. 42](/references/#bass-swa-practice)
+>[Len Bass et. al, 2021, p. 42](/references/#bass2021software)
 
 ### Shortcomings of the SEI Quality Model
 

--- a/_articles/06-quality-requirements.md
+++ b/_articles/06-quality-requirements.md
@@ -20,7 +20,7 @@ These sentences, in natural language, describe requirements or expectations of s
 Formulating requirements in such a way allows a development team to know what needs to be achieved, and what is _good enough_.
 
 Len Bass and his colleagues from the _Software Engineering Institute_ (SEI) coined the term "quality attribute scenarios" for such kind of sentences.
-See [Bass et al, 2022](/references/#bass-swa-practice) for details.
+See [Bass et al, 2021](/references/#bass2021software) for details.
 
 Quality scenarios, for short, are a pragmatic, easy-to-use and general approach to specifying quality requirements.
 

--- a/_pages/30-quality-requirements.md
+++ b/_pages/30-quality-requirements.md
@@ -21,7 +21,7 @@ related qualities
 </span>
 listed below each requirement. <br>
 Within the Software Engineering literature you might find the term "quality scenario" for such examples. 
-That term was coined by authors from the Software Engineering Institute (SEI), especially [Len Bass et. al.](/references/#bass-swa-practice)
+That term was coined by authors from the Software Engineering Institute (SEI), especially [Len Bass et. al.](/references/#bass2021software)
 
 <hr class="with-no-margin"/>
 

--- a/_pages/70-references.md
+++ b/_pages/70-references.md
@@ -5,22 +5,24 @@ permalink: /references/
 order: 70
 ---
 
-<a id="bass-swa-practice"/>
+<a id="bass2021software"/>
 ### Bass et. al: Software Architecture in Practice
 
-Len Bass, Paul Clements, Rick Kazman: Software Architecture in Practice. 4th Edition, Addison Wesley 2022.
+L. Bass, P. Clements, and R. Kazman, Software architecture in practice, 4th ed. Addison-Wesley Professional, 2021.
 
-<a id="boehm-model"/>
+<a id="boehm1976quantitative"/>
 ### Boehm et al: Quantitative Evaluation of Software Quality
 
-B. W. Boehm, J. R. Brown and M. Lipow: Quantitative evaluation of software quality.
+B. W. Boehm, J. R. Brown, and M. Lipow, ‘Quantitative evaluation of software quality’, in Proceedings of the 2nd international conference on Software engineering, 1976, pp. 592–605.
 
-ICSE '76: Proceedings of the 2nd international conference on Software engineeringOctober 1976 Pages 592–605, available [online](https://dl.acm.org/doi/10.5555/800253.807736)
+Available [online](https://dl.acm.org/doi/10.5555/800253.807736)
 
 From the abstract:
 
 >A definitive hierarchy of well-defined, well-differentiated characteristics of software quality is developed. 
 >Its higher-level structure reflects the actual uses to which software quality evaluation would be put; its lower-level characteristics are closely correlated with actual software metric evaluations which can be performed.
+
+Please note: Their approach is covered in [Software Quality Models](/references/#suman2014comparative)
 
 Please note: Boehm's quality model is often (wrongly) dated to a 1978 publication, but in reality the authors published it 1976.
 
@@ -107,6 +109,11 @@ E. Aroms, ‘NIST special publication 800-94 guide to intrusion detection and pr
 
 Available [online](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-94.pdf)
 
+<a id="quality-arc42-org"/>
+### quality.arc42.org
+
+"arc42 Quality Model." quality.arc42.org.  [https://www.quality.arc42.org](https://www.quality.arc42.org) (accessed Mar. 31, 2023).
+
 <a id="robertsons-requirements"/>
 ### Robertson: Mastering the Requirements Process 
 Suzanne Robertson and James Robertson: Mastering the Requirements Process - Getting Requirements Right. Pearson, 3rd edition 2012.
@@ -116,6 +123,12 @@ Suzanne Robertson and James Robertson: Mastering the Requirements Process - Gett
 ### Gernot Starke, Alexander Lorz: Software Architecture Foundations 
 CPSA-F Exam Preparation. VanHaren Publishing, 2021
 
+<a id="suman2014comparative"/>
+### A comparative study of software quality models
+
+M. W. Suman and M. D. U. Rohtak, ‘A comparative study of software quality models’, International Journal of Computer Science and Information Technologies, vol. 5, no. 4, pp. 5634–5638, 2014.
+
+Available [online](https://www.ijcsit.com/docs/Volume%205/vol5issue04/ijcsit20140504177.pdf)
 
 <a id="volere"/>
 ### Volere Requirements Specification Template

--- a/_pages/tag-efficient.md
+++ b/_pages/tag-efficient.md
@@ -57,7 +57,7 @@ Efficient, as we saw above, can mean several different things:
 >* The variation in response time ([jitter](/qualities/jitter))
 >* Usage level of a computing resource
 >
->[Bass et. al, 2022](/references/#bass-swa-practice)
+>[Bass et. al, 2021](/references/#bass2021softwaree)
 
 ### What Stakeholders mean by _efficient_
 

--- a/_pages/tag-flexible.md
+++ b/_pages/tag-flexible.md
@@ -50,7 +50,7 @@ Typical acceptance criteria might include:
 >* Extend to which this modification affects other quality attributes
 >* New defects introduced
 >
->[Bass et. al, 2022](/references/#bass-swa-practice)
+>[Bass et. al, 2021](/references/#bass2021software)
 
 
 ### _flexible_ for Stakeholders

--- a/_pages/tag-operable.md
+++ b/_pages/tag-operable.md
@@ -21,7 +21,7 @@ Deployability is a...
 >Measure of cost, time or process effectiveness for a deployment, 
 >for a series of deployments over time.
 >
->[Bass et. al, 2022](/references/#bass-swa-practice)
+>[Bass et. al, 2021](/references/#bass2021software)
 
 
 ## Typical Acceptance Criteria
@@ -43,7 +43,7 @@ Bass et al define [deployability](/qualities/deployability) as a property, and s
 >* Traceability of the process
 >* Cycle time of the process
 >
->[Bass et. al, 2022](/references/#bass-swa-practice)
+>[Bass et. al, 2021](/references/#bass2021software)
 
 
 

--- a/_pages/tag-reliable.md
+++ b/_pages/tag-reliable.md
@@ -35,7 +35,7 @@ Being trustworthy or performing consistently well.
 >* Time or time interval in which the system may operate in degraded mode
 >* Proportion (e.g. 99%) or rate (e.g. up to 42 per second) of a certain class or type of faults that the system either prevents or handles without failing
 >
->Source: [Bass et. al, 2022, p. 75](/references/#bass-swa-practice)
+>Source: [Bass et. al, 2021, p. 75](/references/#bass2021software)
 
 
 ### What  Stakeholders mean by _reliable_

--- a/_pages/tag-safe.md
+++ b/_pages/tag-safe.md
@@ -45,7 +45,7 @@ Quoted from [Wikipedia/Safety](https://en.wikipedia.org/wiki/Safety)
 >* Amount or percentage of time the system is shut down
 >* Elapsed time to enter and recover (from manual operation, from a safe or degraded mode)
 >
->[Bass et. al, 2022](/references/#bass-swa-practice)
+>[Bass et. al, 2021](/references/#bass2021software)
 
 
 

--- a/_pages/tag-secure.md
+++ b/_pages/tag-secure.md
@@ -34,7 +34,7 @@ permalink: /tag-secure/
 >* How long does it take to recover from successful attack?
 >* How much data is vulnerable to a particular attack?
 >
->[Bass et. al, 2022](/references/#bass-swa-practice)
+>[Bass et. al, 2021](/references/#bass2021software)
 
 
 ### What Stakeholders mean by _secure_

--- a/_pages/tag-suitable.md
+++ b/_pages/tag-suitable.md
@@ -30,7 +30,7 @@ In our opinion it is useful in a broader sense: For example, seen from a testing
 
 ### "Responsibility" as alternative term
 
-[Bass et. al, 2022](/references/#bass-swa-practice) propose to use the term "responsibility" instead of (functional) suitability.
+[Bass et. al, 2021](/references/#bass2021software) propose to use the term "responsibility" instead of (functional) suitability.
 That is, from our perspective, a matter of taste.
 
 ## Typical Acceptance Criteria

--- a/_pages/tag-usable.md
+++ b/_pages/tag-usable.md
@@ -50,7 +50,7 @@ The main idea of _usability_ is that a system shall be designed with (generalize
 >* ratio of successful operations to total operations
 >* amount of time or data lost when an error occurs 
 >
->[Bass et. al, 2022](/references/#bass-swa-practice)
+>[Bass et. al, 2021](/references/#bass2021software)
 
 ### What Stakeholders mean by _usable_
 

--- a/qualities/D/_posts/2022-12-28-deployability.md
+++ b/qualities/D/_posts/2022-12-28-deployability.md
@@ -13,7 +13,7 @@ See also [#operable](/tag-operable).
 >Deployability refers to a property of software indicating that it may be deployed, that is, allocated to an environment for execution—within a predictable and acceptable amount of time and effort. 
 >Moreover, if the new deployment is not meeting its specifications, it may be rolled back, again within a predictable and acceptable amount of time and effort. 
 >
->[Bass et al, 2022](/references/#bass-swa-practice)
+>[Bass et al, 2021](/references/#bass2021software)
 
 <hr class="with-no-margin"/>
 

--- a/qualities/F/_posts/2022-12-28-functionality.md
+++ b/qualities/F/_posts/2022-12-28-functionality.md
@@ -11,12 +11,12 @@ The main system or product features.
 
 >Functionality is the ability of the system to do the work for which it was intended.
 >
->[Bass et al, 2022](/references/#bass-swa-practice)
+>[Bass et al, 2021](/references/#bass2021software)
 
 <hr class="with-no-margin"/>
 
 >Functionality describes what the system does and quality describes how well the system does its function. That is, qualities are attributes of the system and function is the purpose of the system. 
 >
->[Bass et al, 2022](/references/#bass-swa-practice)
+>[Bass et al, 2021](/references/#bass2021software)
 
 <hr class="with-no-margin"/>

--- a/qualities/T/_posts/2022-12-28-traceability.md
+++ b/qualities/T/_posts/2022-12-28-traceability.md
@@ -10,7 +10,7 @@ permalink: /qualities/traceability
 >It also includes the test cases that were run on that element and the tools that were used to produce the element. 
 >Errors in tools used in the deployment pipeline can cause problems in production.
 >
->[Bass et al, 2022](/references/#bass-swa-practice)
+>[Bass et al, 2021](/references/#bass2021software)
 
 <hr class="with-no-margin"/>
 

--- a/requirements/_posts/2000-03-02-low-effort-deployment.md
+++ b/requirements/_posts/2000-03-02-low-effort-deployment.md
@@ -17,7 +17,7 @@ A new release of an authentication/authorization service (which our product uses
 It takes less than 40 hours of elapsed time and no more than 120 person-hours of effort. 
 The deployment introduces no defects and no SLA is violated.
 
-Idea: >[Bass et. al, 2022](/references/#bass-swa-practice)
+Idea: >[Bass et. al, 2021](/references/#bass2021software)
 
 </div><br>
 

--- a/requirements/_posts/2000-04-05-server-fails-no-downtime.md
+++ b/requirements/_posts/2000-04-05-server-fails-no-downtime.md
@@ -9,7 +9,7 @@ permalink: /requirements/server-fails-operation-without-downtime
 
 >A server in a server farm fails during normal operation, and the system informs the operator and continues to operate with no downtime.
 >
->[Len Bass et. al, 2022, p. 76](/references/#bass-swa-practice)
+>[Len Bass et. al, 2021, p. 76](/references/#bass2021software)
 
 </div>
 

--- a/requirements/_posts/2000-05-01-life-critical-sensor-failure.md
+++ b/requirements/_posts/2000-05-01-life-critical-sensor-failure.md
@@ -7,7 +7,7 @@ permalink: /requirements/backup-patient-monitoring-sensor
 
 <div class="quality-requirement" markdown="1">
 
-Idea: [Bass et. al, 2022](/references/#bass-swa-practice)
+Idea: [Bass et. al, 2021](/references/#bass2021software)
 
 **Background**: The system monitors patients several health and vitality parameters (e.g. heartbeat frequency and amplitude, blood flow in coronary artery etc)
 

--- a/requirements/_posts/2000-06-06-employee-tries-to-modify-pay-rate.md
+++ b/requirements/_posts/2000-06-06-employee-tries-to-modify-pay-rate.md
@@ -13,7 +13,7 @@ permalink: /requirements/employee-attempts-to-modify-pay-rate
 
 **Measure**: The correct data is restored within one day.
 
-Source: [Bass et. al, 2022](/references/#bass-swa-practice)
+Source: [Bass et. al, 2021](/references/#bass2021software)
 
 </div><br>
 

--- a/requirements/_posts/2000-07-01-test-with-path-coverage-in-30min.md
+++ b/requirements/_posts/2000-07-01-test-with-path-coverage-in-30min.md
@@ -7,7 +7,7 @@ permalink: /requirements/test-with-path-coverage-30min
 
 <div class="quality-requirement" markdown="1">
 
-Idea: [Bass et. al, 2022](/references/#bass-swa-practice)
+Idea: [Bass et. al, 2021](/references/#bass2021software)
  
 **Stimulus**: The developer completes a code unit.
 


### PR DESCRIPTION
- 03-iso-25010-shortcomings uses references file instead of local references
- use ieee citation for 03-iso-25010-shortcomings references
- fix reference suman2014comparative

See [111](https://github.com/arc42/quality.arc42.org-site/issues/111)