### PR TITLE
Color distinguish quals reqs in search #148

### DIFF
--- a/_includes/search-req-header.html
+++ b/_includes/search-req-header.html
@@ -1,0 +1,48 @@
+{% assign page = include.page %}
+
+<header>
+    <div class="panel">
+        <h1>
+            {% if include.link %}
+            <a class="post-link" href="{{ page.url | prepend: site.baseurl }}" style="color: var(--req-text-color);">{{ page.title }}</a>
+            {% else %}
+            {{ page.title }}
+            {% endif %}
+        </h1>
+
+        <ul class="tags">
+            {% assign tags_num = (page.tags | size) %}
+            {% if tags_num > 0 %}
+            <li><i class="fa fa-tags" style="color: var(--req-text-color);"></i></li>
+            {% endif %}
+            {% for tag in page.tags %}
+            <li>
+                <a class="tag" href="{{ '/tag-' | append: tag | prepend: site.baseurl }}" style="color: var(--req-text-color);">#{{ tag }}</a>
+            </li>
+            {% endfor %}
+        </ul>
+
+        <div class="clearfix">
+            <ul class="meta">
+                
+                {% if page.author %}
+                <li>
+                    <a href="{{ '/search/?a=' | append: page.author | prepend: site.baseurl }}">
+                        <i class="fa fa-user"></i>
+                        {{ page.author }}
+                    </a>
+                </li>
+                {% if page.icons %}
+                <li>
+                    <ul class="icons">
+                        {% include icons.html icons=page.icons %}
+                    </ul>
+                </li>
+                {% endif %}
+                {% endif %}
+            </ul>
+        </div>
+    </div>
+
+
+</header>

--- a/_pages/search.html
+++ b/_pages/search.html
@@ -18,7 +18,7 @@ share: false
     <div id="{{ post.id | replace: '/', '-' }}" style="display: none;">
         <div class="article-wrapper">
             <article>
-                {% include article-header.html page=post link=true share=false %}
+                {% include search-req-header.html page=post link=true share=false %}
             </article>
         </div>
         <hr class="with-no-margin"/>

--- a/_pages/search.html
+++ b/_pages/search.html
@@ -18,7 +18,11 @@ share: false
     <div id="{{ post.id | replace: '/', '-' }}" style="display: none;">
         <div class="article-wrapper">
             <article>
+                {% if post.categories contains "requirements" %}
                 {% include search-req-header.html page=post link=true share=false %}
+                {% else %}
+                {% include article-header.html page=post link=true share=false %}
+                {% endif %}
             </article>
         </div>
         <hr class="with-no-margin"/>


### PR DESCRIPTION
 Closes issue #148, please review and merge :)

The icon stays the same for both requirements and qualities, as this is the icon for the tags, and both of them contain tags. The color changes depending on whether the search result is a quality or a requirement. 
See screenshot below for an example.

<img width="930" alt="Bildschirmfoto 2023-12-12 um 22 48 29" src="https://github.com/arc42/quality.arc42.org-site/assets/7078370/b7f4ea3a-e089-4a9d-977e-283d7066c262">

