### PR TITLE
Use bundle exec in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,6 @@ services:
       - ./vendor/bundle/:/usr/local/bundle
     ports:
       - "4000:4000"
-    command: jekyll serve --trace --host 0.0.0.0 --watch --incremental --config _config.yml
+    command: bundle exec jekyll serve --trace --host 0.0.0.0 --watch --incremental --config _config.yml
     environment:
       - JEKYLL_ENV=development


### PR DESCRIPTION
In is recommended to use bundle exec jekyll serve when using a bundler. This enforces using the bundled gem instead of a global one.