### PR TITLE
Update the reference to the iso25010 to use the released link and updated definitions

### DIFF
--- a/_pages/tag-flexible.md
+++ b/_pages/tag-flexible.md
@@ -18,9 +18,11 @@ Easy to:
 
 ### Definition
 
->Capability of a product to serve a different or expanded set of requirements or contexts of use; or the ease with which the product can be adapted to changes in its requirements, contexts of use, or system environment
+>Capability of a product to be adapted to changes in its requirements, contexts of use, or system environment.
+> 
+>Note: Flexibility to context of use should consider two distinguished aspects, i.e. technical and non-technical. The technical aspect is related with the execution environment of products, such as software, hardware and communication facility; and the non-technical aspect is related with the social environment, such as user and task, and the physical environment, such as climate and nature.
 >
->[ISO-25010-2022](/references/#iso-25010-2022)
+>[ISO-25010-2023](/references/#iso-25010-2023)
 
 
 <hr/>

--- a/_pages/tag-reliable.md
+++ b/_pages/tag-reliable.md
@@ -19,7 +19,7 @@ Being trustworthy or performing consistently well.
 >
 >Note: Wear does not occur in software. Limitations in reliability are due to results from faults in requirements, design and implementation, or from contextual changes.”
 >
->[ISO-25010-2022](/references/#iso-25010-2022)
+>[ISO-25010-2023](/references/#iso-25010-2023)
 </div><br>
 
 

--- a/_pages/tag-safe.md
+++ b/_pages/tag-safe.md
@@ -31,7 +31,7 @@ Quoted from [Wikipedia/Safety](https://en.wikipedia.org/wiki/Safety)
 
 >Capability of a product under defined conditions to avoid a state in which human life, health, property, or the environment is endangered.
 >
->[ISO-25010-2022](/references/#iso-25010-2022)
+>[ISO-25010-2023](/references/#iso-25010-2023)
 
 
 ## Typical Acceptance Criteria

--- a/_pages/tag-secure.md
+++ b/_pages/tag-secure.md
@@ -20,7 +20,7 @@ permalink: /tag-secure/
 
 >Capability of a product to protect information and data so that persons or other products have the degree of data access appropriate to their types and levels of authorization, and to defend against attack patterns by malicious actors.
 >
->[ISO-25010-2022](/references/#iso-25010-2022)
+>[ISO-25010-2023](/references/#iso-25010-2023)
 
 ## Typical Acceptance Criteria
 

--- a/_pages/tag-suitable.md
+++ b/_pages/tag-suitable.md
@@ -20,7 +20,7 @@ Users found that to be overly specific, see the discussion [here](https://github
 
 >(Functional) Suitability:
 >
->...provide(s) functions that meet stated and implied needs of intended users when it is used under specified conditions.
+>...provides functions that meet stated and implied needs of intended users when it is used under specified conditions.
 >
 >[ISO-25010-2023](/references/#iso-25010-2023)
 

--- a/_pages/tag-suitable.md
+++ b/_pages/tag-suitable.md
@@ -20,9 +20,9 @@ Users found that to be overly specific, see the discussion [here](https://github
 
 >(Functional) Suitability:
 >
->...provides functions that meet stated and implied needs when used under specified conditions.
+>...provide(s) functions that meet stated and implied needs of intended users when it is used under specified conditions.
 >
->[ISO-25010-2022](/references/#iso-25010-2022)
+>[ISO-25010-2023](/references/#iso-25010-2023)
 
 The ISO restricts _Suitability_ to functional aspects. 
 In our opinion, it is useful in a broader sense: For example, seen from a testing perspective, suitable can mean "easy to test". 

--- a/_pages/tag-usable.md
+++ b/_pages/tag-usable.md
@@ -17,8 +17,8 @@ The main idea of _usability_ is that a system shall be designed with (generalize
 
 ### Definitions:
 
->Capability of a product to be used by specified users to exchange information between a user and an interactive system via the user interface to complete the intended task.
->[ISO-25010, v2022](/references/#iso-25010-2022)
+>Capability of a product to be interacted with by specified users to exchange information between a user and a system via the user interface to complete the intended task.
+>[ISO-25010-2023](/references/#iso-25010-2023)
 
 <hr class="with-no-margin"/>
 


### PR DESCRIPTION
Partial fix for #156
Update the references in the tag-* documents to refer to the correct iso reference
Also, check the definitions match the published definition with iso 25010:2023