### PR TITLE
Fix: Standards header text color

### DIFF
--- a/assets/css/arc42-quality.css
+++ b/assets/css/arc42-quality.css
@@ -82,6 +82,10 @@ a.hov.tags.standard {
   background-color: var(--standard-background-color);
 }
 
+#standard-header h1 {
+  color: var(--standard-text-color);
+}
+
 a.reqs {
   color: var(--req-text-color);
 }


### PR DESCRIPTION
The Standards page header and _standards collection page headers had insufficient contrast due to blue text on a yellow background.

This was because the CSS rule for #standard-header only set the background-color and not the text color.

This change adds a CSS rule to explicitly set the text color for the h1 element within the #standard-header, ensuring it uses the correct --standard-text-color variable.