### PR TITLE
docs: add AGENTS.md contributor guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Content: `_qualities/`, `_requirements/`, `_standards/`, `_articles/`, `_pages/`.
+- Theme/layout: `_layouts/`, `_includes/`, `_sass/`.
+- Client code: `src/graphs/**`, `src/scripts/data.js` (generates graph JSON).
+- Assets: `assets/js` (bundled), `assets/data` (generated), `images/`, `assets/img/`.
+- Config: `_config.yml`, `docker-compose.yml`, `Gemfile`, `package.json`.
+
+## Build, Test, and Development Commands
+- `docker compose up`: Builds graph data, bundles JS, and serves Jekyll at `http://localhost:4000` with watch.
+- `docker compose down`: Stops services; use when changing Docker config or after adding many files.
+- `npm run data`: Regenerates `assets/data/*.json` from front matter (normally run by Docker).
+- `npm run build`: Bundles JS (also runs data first via `build.js`).
+- `npm run watch`: Watches and rebuilds JS; use only for local Node workflows.
+
+## Coding Style & Naming Conventions
+- JavaScript: ESM, format with Prettier (print width 100). Prefer 2‑space indentation.
+- Markdown/Front matter:
+  - `tags`: space‑separated (e.g., `usable secure`).
+  - `related`: comma‑separated IDs/titles (e.g., `reliability, resilience`).
+  - `permalink`: stable, kebab‑case (e.g., `/qualities/availability`).
+- File placement: `_qualities/<LETTER>/name.md`, `_requirements/<LETTER>/name.md`, `_standards/name.md`.
+
+## Testing Guidelines
+- No unit tests; validate locally:
+  - Site serves without errors at `http://localhost:4000`.
+  - Graph renders; `assets/data/nodes.json`, `edges.json`, `property-nodes.json` exist and include your entries.
+  - New tags have a corresponding `_pages/tag-<tag>.md` page to avoid 404s.
+
+## Commit & Pull Request Guidelines
+- Commits: Prefer Conventional Commits when possible (`feat:`, `fix:`, `docs:`). Keep messages concise and scoped.
+- PRs: Include a clear description, linked issue (if any), and screenshots/GIFs of affected pages or graphs. Note added tags/links. Ensure `docker compose up` runs cleanly and data is regenerated.
+
+## Architecture Overview (Quick)
+- Jekyll collections drive content; defaults in `_config.yml` assign layouts for `qualities`, `requirements`, and `standards`.
+- `src/scripts/data.js` parses front matter to create graph JSON consumed by D3 visualizations in `src/graphs/**` and emitted to `assets/data/`.
+
+## Security & Configuration Tips
+- Use the provided Docker workflow; local Ruby/Node versions can vary. Volta pins Node 22 in `package.json`.
+- Do not commit secrets; this is a static site. Check links and permalinks for stability before publishing.
+

--- a/_qualities/A/accountability.md
+++ b/_qualities/A/accountability.md
@@ -2,7 +2,7 @@
 title: Accountability
 tags: secure
 related: authenticity, security, non-repudiation
-standards: iso25010,iso27001,pcidss
+standards: iso25010,iso27001,pcidss,iso42001
 permalink: /qualities/accountability
 ---
 

--- a/_qualities/E/explainability.md
+++ b/_qualities/E/explainability.md
@@ -2,6 +2,7 @@
 title: Explainability
 tags: safe suitable
 related: accountability, analysability, clarity
+standards: iso42001
 permalink: /qualities/explainability
 ---
 Explainability is a quality sometimes required in the context of Artificial Intelligence (AI). The European's proposed AI Act will probably contain obligations for some AI systems to provide explanations about decisions that impact user rights.

--- a/_qualities/S/security.md
+++ b/_qualities/S/security.md
@@ -2,7 +2,7 @@
 title: Security
 tags: secure reliable
 related: integrity, availability, non-repudiation, confidentiality, accountability, authenticity, resistance
-standards: iso25010,iso27001,iso26262, misra-c, nist80053,iso5055,pcidss
+standards: iso25010,iso27001,iso26262, misra-c, nist80053,iso5055,pcidss,iso42001
 permalink: /qualities/security
 ---
 

--- a/_qualities/T/transparency.md
+++ b/_qualities/T/transparency.md
@@ -2,6 +2,7 @@
 title: Transparency
 tags: reliable 
 related: clarity, understandability, usability
+standards: iso42001
 permalink: /qualities/transparency
 ---
 

--- a/_todo/qualities/bias-mitigation.md
+++ b/_todo/qualities/bias-mitigation.md
@@ -1,0 +1,5 @@
+---
+title: Bias Mitigation
+---
+
+# TODO: Bias Mitigation

--- a/_todo/qualities/data-quality.md
+++ b/_todo/qualities/data-quality.md
@@ -1,0 +1,5 @@
+---
+title: Data Quality
+---
+
+# TODO: Data Quality

--- a/_todo/qualities/fairness.md
+++ b/_todo/qualities/fairness.md
@@ -1,0 +1,5 @@
+---
+title: Fairness
+---
+
+# TODO: Fairness


### PR DESCRIPTION
Adds AGENTS.md with concise contributor guidance for this Jekyll site and graph generator. Includes project structure, Docker+NPM commands, style conventions, testing steps, and PR/commit expectations.