### PR TITLE
Update to Contact page

### DIFF
--- a/_pages/90-contact.md
+++ b/_pages/90-contact.md
@@ -14,10 +14,10 @@ Please let us know - we're listening:
 <li><a href="xmxaxixlxtxo:ixnxfxox@xaxrxcx4x2x.xdxex" onmouseover="this.href=this.href.replace(/x/g,'');"><i class="fa fa-fw fa-envelope"></i> Email (our adress is spam-protected)</a></li>
 <li><a href="https://linkedin.com/in/gernotstarke"><i class="fab fa-fw fa-linkedin" aria-hidden="true"></i> LinkedIn</a></li>
 
-<li><a href="https://github.com/arc42/quality.arc42.org-site/issues"><i class="fab fa-fw fa-github" aria-hidden="true"></i>github issue tracker</a></li>
+<li><a href="https://github.com/arc42/quality.arc42.org-site/issues"><i class="fab fa-fw fa-github" aria-hidden="true"></i>GitHub issue tracker</a></li>
 <li>
-    <a href="https://stackoverflow.com/questions/tagged/arc42">
-        <i class="fab fa-fw fa-stack-overflow" aria-hidden="true"></i>Stackoverflow</a>
+    <a href="https://stackoverflow.com/questions/tagged/arc42"><i class="fab fa-fw fa-stack-overflow" aria-hidden="true"></i>Stack Overflow</a> and
+    <a href="https://softwareengineering.stackexchange.com/"><i class="fab fa-fw fa-stack-exchange" aria-hidden="true"></i>Software Engineering Stack Exchange</a>
 </li>
 </ul>
 


### PR DESCRIPTION
Three changes to the Contact page:

1. Corrected capitalization of "GitHub" to match branding.
2. Corrected capitalization of "Stack Overflow" to match branding.
3. Added link to Software Engineering Stack Exchange.

Full disclosure: I'm [a community-elected volunteer moderator on Software Engineering Stack Exchange](https://softwareengineering.stackexchange.com/users/4/thomas-owens). We currently have [5 posts that explicitly mention Arc42](https://softwareengineering.stackexchange.com/search?q=arc42). Questions about quality and standards are far more likely to be on topic on Software Engineering than Stack Overflow, which expects questions to be about coding (and include code) or coding tools.