### PR TITLE
fix(references): incorrect ISO 25010:2023 link

### DIFF
--- a/_standards/iso/iso-25010.md
+++ b/_standards/iso/iso-25010.md
@@ -35,6 +35,6 @@ It defines a product quality model which is composed of nine characteristics, th
 
 ## References
 
-- [ISO/IEC 25010:2023](https://www.iso.org/standard/82895.html)
+- [ISO/IEC 25010:2023](https://www.iso.org/standard/78176.html)
 - ISO/IEC 25000 series (SQuaRE)
 


### PR DESCRIPTION
On the [ISO/IEC 25010 standards](https://quality.arc42.org/standards/iso-25010) page the reference for `ISO/IEC 25010:2023` was pointing to an unrelated ISO page:

-  ISO 7681:2024 Natural rubber field latex — Determination of dry rubber content

I replaced the [wrong](https://www.iso.org/standard/82895.html) with the correct ISO/IEC [link](https://www.iso.org/standard/78176.html)