### PR TITLE
Extract navigation into data file

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,0 +1,27 @@
+main:
+  - title: Home
+    url: /
+  - title: How to Use this Site
+    url: /how-to-use-this-site/
+  - title: Quality Dimensions
+    url: /dimensions/
+  - title: Quality Characteristics
+    url: /qualities/
+  - title: Quality Requirements
+    url: /requirements/
+  - title: Solution Approaches
+    url: /approaches/
+  - title: Quality Standards
+    url: /standards/
+  - title: Quality Aliases and Synonyms
+    url: /aliases/
+  - title: Q42 for ISO-25010 Users
+    url: /q42-for-iso-users/
+  - title: Background on "Quality"
+    url: /articles/
+  - title: References
+    url: /references/
+  - title: About this Site
+    url: /aboutthissite/
+  - title: Contact
+    url: /contact/

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -81,12 +81,19 @@
                 </form>
             </div>
             <ul>
+                {% assign navigation_items = site.data.navigation.main %}
+                {% if navigation_items %}
+                {% for navigation_item in navigation_items %}
+                <li><a class="page-link" href="{{ navigation_item.url | prepend: site.baseurl }}">{{ navigation_item.title }}</a></li>
+                {% endfor %}
+                {% else %}
                 {% assign pages = site.pages | sort: 'order' %}
                 {% for page in pages %}
                 {% if page.title and page.hide != true %}
                 <li><a class="page-link" href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a></li>
                 {% endif %}
                 {% endfor %}
+                {% endif %}
             </ul>
             <ul class="icons">
                 {% include icons.html icons=site.icons %}


### PR DESCRIPTION
Closes #419

## Summary
- add `_data/navigation.yml` with the current visible sidebar pages under `main`
- switch the default layout sidebar to read from `site.data.navigation.main`
- keep the old `site.pages | sort: 'order'` loop as a fallback if the data file is missing

## Validation
- `bundle install`
- `bundle exec jekyll build`