### PR TITLE
Install Minimal Mistakes and align config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,12 @@ gem "json", ">= 2.3.0"
 gem "kramdown", ">= 2.3.0"
 gem "addressable", ">= 2.8.0"
 gem "commonmarker", ">= 0.23.4"
+gem "minimal-mistakes-jekyll"
 
 group :jekyll_plugins do
     gem "webrick"
     gem 'github-pages'
+    gem "jekyll-include-cache"
     gem 'jekyll-seo-tag'
     gem "jekyll-github-metadata"
     gem "jekyll-sitemap"

--- a/_config.yml
+++ b/_config.yml
@@ -18,8 +18,25 @@ title: arc42 Quality Model
 description: quality characteristics, explained.
 avatar: /assets/img/arc42logosquare.webp
 favicon: /assets/img/arc42logosquare.webp
+logo: /assets/img/arc42logosquare.webp
 language: en
+locale: en-US
 repository: arc42/quality.arc42.org-site
+theme: minimal-mistakes-jekyll
+minimal_mistakes_skin: default
+masthead_title: arc42 Quality Model
+search: false
+search_full_content: true
+breadcrumbs: false
+
+footer:
+  links:
+    - label: GitHub
+      icon: fab fa-fw fa-github
+      url: https://github.com/arc42/quality.arc42.org-site
+    - label: Status
+      icon: fas fa-fw fa-chart-bar
+      url: https://status.arc42.org
 
 #
 # Icons and Social-Media accounts
@@ -53,6 +70,7 @@ plugins:
   - jemoji
   - jekyll-paginate
   - jekyll-github-metadata
+  - jekyll-include-cache
 
 #
 # tags, collections etc -

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - .:/site
     ports:
       - "4000:4000"
-    command: bundle exec jekyll serve --incremental --watch --host 0.0.0.0
+    command: sh -lc "bundle check || bundle install && bundle exec jekyll serve --incremental --watch --host 0.0.0.0"
 
   playwright:
     image: mcr.microsoft.com/playwright:v1.58.2-jammy


### PR DESCRIPTION
Closes #420

## Summary
- add the `minimal-mistakes-jekyll` theme gem and `jekyll-include-cache` plugin
- align `_config.yml` with core Minimal Mistakes settings while keeping built-in search disabled for now
- make the Jekyll Docker service run `bundle check || bundle install` before serving so new gems are available in the container

## Validation
- `bundle install`
- `bundle exec jekyll build`
- `docker compose config`