### PR TITLE
Add additional links to the domain language in appropriate places

### DIFF
--- a/_articles/05-arc42-quality-model.md
+++ b/_articles/05-arc42-quality-model.md
@@ -52,6 +52,7 @@ That enables different _access patterns_ to this website:
 3. Start with asking your stakeholders for their generic or specific requirements - and then continue with 1. or 2.
 4. Finally, you might read through the list of [**example requirements**](/requirements).
 
+Reference [our domain language](/how-to-use-this-site/#our-domain-language) for a visual representation of terms.
 
 ### Stakeholder first
 

--- a/_pages/10-quality-dimensions.md
+++ b/_pages/10-quality-dimensions.md
@@ -8,7 +8,7 @@ order: 10
 Dimensions (also known as _tags_ or _labels_) are used to structure the fairly large set of quality characteristics.
 The top-level dimensions overlap by design and are not orthogonal.
 
-Consider an excerpt of our domain language (aka _metamodel_):
+Consider an excerpt of our [domain language (aka _metamodel_)](/how-to-use-this-site/#our-domain-language):
 
 
 ![Dimensions and quality characteristics](/images/domain-language/q42-dimensions-qualities-requirements.webp)


### PR DESCRIPTION
I was a bit frustrated looking for the nice visual representation of the domain language, so I added some more hyperlinks to it.

I've not tested the visual representation yet, since jekyll fails with a dependency error in "make dev" on main.