### PR TITLE
content: add human oversight section to controllability (#451)

### DIFF
--- a/_data/quality-synonyms.yml
+++ b/_data/quality-synonyms.yml
@@ -124,3 +124,5 @@ sustainability:
 # Controllability (user controllability is the ISO 25059 sub-characteristic name)
 controllability:
   - user-controllability
+  - human-controllability
+  - human-oversight

--- a/_qualities/C/controllability.md
+++ b/_qualities/C/controllability.md
@@ -1,8 +1,9 @@
 ---
 title: Controllability
+aka: [Human Controllability, Human Oversight]
 tags: [usable, operable]
-related: [usability, autonomy, operability, interaction-capability]
-standards: [ieee2857, iso25059]
+related: [usability, autonomy, operability, interaction-capability, governability, intervenability, auditability]
+standards: [ieee2857, iso25059, iso42001, nistairmf]
 permalink: /qualities/controllability
 ---
 
@@ -29,3 +30,41 @@ permalink: /qualities/controllability
 > [ISO-25059](/references/#iso-25059)
 
 User controllability is a property of an AI system such that a controller can intervene in its functioning in a timely manner.
+
+<hr class="with-no-margin"/>
+
+### Human Oversight in AI Systems
+
+Where a system acts with a degree of autonomy, controllability is what keeps a person able to understand, direct, and if necessary stop that action. Regulation and management standards treat this as an explicit design obligation, not as an incidental property of the user interface.
+
+> High-risk AI systems shall be designed and developed in such a way, including with appropriate human-machine interface tools, that they can be effectively overseen by natural persons during the period in which they are in use.
+>
+> [EU AI Act, Article 14: Human oversight](https://ai-act-service-desk.ec.europa.eu/en/ai-act/article-14)
+
+Article 14(4) names the capabilities that oversight requires: understanding the system's capacities and limitations, remaining aware of automation bias, correctly interpreting the output, being able to decide not to use the system or to disregard or override its output, and being able to intervene or interrupt operation through a stop button or comparable procedure that halts the system in a safe state.
+
+<hr class="with-no-margin"/>
+
+ISO/IEC 42001 places oversight in the organizational dimension: an AI management system defines accountability for each AI system, which decisions require human involvement, and how that oversight is documented and reviewed. Controllability therefore has a governance side — see [governability](/qualities/governability) — as well as a technical one.
+
+[ISO/IEC 42001](/standards/iso-42001)
+
+<hr class="with-no-margin"/>
+
+NIST AI RMF covers oversight in two places. GOVERN 3.2 asks for policies that "define and differentiate roles and responsibilities for human-AI configurations and oversight of AI systems". MANAGE 2.4 asks that mechanisms be in place and applied "to supersede, disengage, or deactivate AI systems that demonstrate performance or outcomes inconsistent with intended use".
+
+[NIST AI RMF Core](https://airc.nist.gov/airmf-resources/airmf/5-sec-core/)
+
+<hr class="with-no-margin"/>
+
+### Typical Oversight Mechanisms
+
+- Human-in-the-loop approval before an action with material consequences
+- Human-on-the-loop monitoring, with the ability to intervene while the system runs
+- Override or correction of a system decision, with the override itself recorded
+- Stop function that halts operation in a defined, safe state
+- Rollback to a previous state after an unwanted action
+- Escalation to a human when confidence, novelty, or risk thresholds are exceeded
+- Audit trail that makes past decisions and interventions reconstructable — see [auditability](/qualities/auditability)
+
+Oversight is only real if the intervention point is reachable in time: a control that cannot be exercised before the system's action takes effect does not make the system controllable.

--- a/_qualities/H/human-controllability.md
+++ b/_qualities/H/human-controllability.md
@@ -1,0 +1,7 @@
+---
+title: Human Controllability
+alias_of: controllability
+redirect_to: /qualities/controllability
+layout: redirect
+permalink: /qualities/human-controllability
+---

--- a/_qualities/H/human-oversight.md
+++ b/_qualities/H/human-oversight.md
@@ -1,0 +1,7 @@
+---
+title: Human Oversight
+alias_of: controllability
+redirect_to: /qualities/controllability
+layout: redirect
+permalink: /qualities/human-oversight
+---


### PR DESCRIPTION
Resolves #451 by folding **Human Controllability** into the existing [`controllability`](https://quality.arc42.org/qualities/controllability) quality rather than adding a sibling node.

### Rationale

The model already has `controllability` (ISO/IEC 25059 defines it for AI systems) plus `governability`, `intervenability` and `auditability`. "Human controllability" is `controllability` scoped to a particular actor, not a property that no existing node can express — and `user-controllability` already exists as an alias stub, so this follows the established precedent.

### Changes to `_qualities/C/controllability.md`

- `aka: [Human Controllability, Human Oversight]` — surfaces both terms in the A–Z explorer, site search, and the on-page "Also known as" block
- New section **Human Oversight in AI Systems**, citing:
  - EU AI Act Article 14 (paragraph 1 quoted; the paragraph 4(a)–(e) capabilities summarised)
  - ISO/IEC 42001 — oversight as an organizational/governance obligation
  - NIST AI RMF GOVERN 3.2 and MANAGE 2.4 (quoted verbatim)
- New subsection **Typical Oversight Mechanisms** (human-in-the-loop, human-on-the-loop, override, stop function, rollback, escalation, audit trail)
- `standards:` + `iso42001`, `nistairmf`
- `related:` + `governability`, `intervenability`, `auditability`

The EU AI Act is cited inline — the repo has no `_standards/` page for it yet, so it is not in the `standards:` array.

### Verification

- `npm run test:links` — all links valid
- Graph data regenerated: `controllability` now carries `iso42001`/`nistairmf` standards edges and the three new `related` edges
- Search index contains both new alias phrases
- Jekyll build in Docker: page renders "Also known as: Human Controllability, Human Oversight, User Controllability"; all standard and quality links resolve

https://claude.ai/code/session_017zkfTswvAjeCY2bRfFnCyQ