### PR TITLE
graph: make the domain-language accent bars consistent (+ dev port 4045 -> 4245)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 - Config: `_config.yml`, `Gemfile`, `docker-compose.yml`, `package.json`.
 
 ## Build, Test, and Development
-- `docker compose up`: builds the Jekyll site and serves on `http://localhost:4045/` — this site's fixed dev port, see `raw/port-assignment.md` in meta.arc42.org.
+- `docker compose up`: builds the Jekyll site and serves on `http://localhost:4245/` — this site's fixed dev port, see `raw/port-assignment.md` in meta.arc42.org.
 - `docker compose down`: stops stack so compose changes take effect on next start.
 - `npm run build`: generate graph data and bundle JS to `assets/js` once.
 - `npm run watch`: build and watch for JS changes.

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # just on the host side, so its "Server address:" startup banner names the real
 # port -- which is also why the Playwright container reaches the site at
 # http://jekyll:$(SITE_PORT) rather than at Jekyll's default 4000.
-SITE_PORT ?= 4045
+SITE_PORT ?= 4245
 
 .PHONY: help build clean dev down doctor diagnose test wcag-test wcag-test-strict lighthouse-test assets prettier-write
 

--- a/README.md
+++ b/README.md
@@ -107,18 +107,24 @@ make build
 make dev
 ```
 
-The site serves on http://localhost:4045. Content and front-matter changes
+The site serves on http://localhost:4245. Content and front-matter changes
 are picked up live; rebuild images only when `package-lock.json` or
 `Gemfile.lock` change.
 
-The port is fixed at **4045**, not Jekyll's default 4000, so this dev stack can
+The port is fixed at **4245**, not Jekyll's default 4000, so this dev stack can
 run alongside the other arc42 sites' dev servers without a clash — see
-`raw/port-assignment.md` in meta.arc42.org for the full assignment. Jekyll binds
-4045 inside the container as well as on the host, so its "Server address:"
-startup banner names the real port. Four places must stay in step: `SITE_PORT`
-in the `Makefile`, the mapping plus `--port` in `docker-compose.yml`, `CMD` in
-`_docker/jekyll/Dockerfile`, and the `UI_BASE_URL` the Playwright service uses
-to reach the site (`http://jekyll:4045`). The `wcag-refresh` GitHub workflow
+`raw/port-assignment.md` in meta.arc42.org for the full assignment. arc42 dev
+ports live in the `42xx` block because that whole range is free of the ports
+browsers refuse to connect to; the site's earlier port, 4045, was one of them
+("lockd" on the WHATWG bad-port list, enforced by Chrome and Firefox), which
+made the dev server unreachable and every Playwright spec fail with
+`ERR_UNSAFE_PORT`. Never assign 4045 or 4190. Jekyll binds 4245 inside the
+container as well as on the host, so its "Server address:" startup banner names
+the real port. Five places must stay in step: `SITE_PORT` in the `Makefile`, the
+mapping plus `--port` in `docker-compose.yml`, `CMD` in
+`_docker/jekyll/Dockerfile`, the `UI_BASE_URL` the Playwright service uses to
+reach the site (`http://jekyll:4245`), and the `baseURL` fallback in
+`_docker/playwright/playwright.config.ts`. The `wcag-refresh` GitHub workflow
 still uses 4000 — it runs its own Jekyll on a CI runner with no siblings around,
 so nothing there can clash.
 
@@ -127,7 +133,7 @@ so nothing there can clash.
 | Command                 | What it does                                                                                                                               |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `make build`            | Build Docker images. Slow path — runs `bundle install` and `npm ci` inside the images.                                                     |
-| `make dev`              | Start the prebuilt dev stack (esbuild watcher + Jekyll on port 4045).                                                                      |
+| `make dev`              | Start the prebuilt dev stack (esbuild watcher + Jekyll on port 4245).                                                                      |
 | `make doctor`           | Sanity-check the dev stack: Docker up, site reachable, key routes (including alias redirects) responding.                                  |
 | `make clean`            | Remove `_site/`.                                                                                                                           |
 | `make test`             | Run Playwright UI tests in Docker. Starts the stack first if needed.                                                                       |

--- a/_docker/jekyll/Dockerfile
+++ b/_docker/jekyll/Dockerfile
@@ -19,4 +19,4 @@ RUN chmod +x /usr/local/bin/jekyll-entrypoint
 WORKDIR /site
 
 ENTRYPOINT ["jekyll-entrypoint"]
-CMD ["bundle", "exec", "jekyll", "serve", "--incremental", "--watch", "--host", "0.0.0.0", "--port", "4045", "--force_polling"]
+CMD ["bundle", "exec", "jekyll", "serve", "--incremental", "--watch", "--host", "0.0.0.0", "--port", "4245", "--force_polling"]

--- a/_docker/playwright/playwright.config.ts
+++ b/_docker/playwright/playwright.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     ["html", { open: "never", outputFolder: path.join(repoRoot, "playwright-report") }],
   ],
   use: {
-    baseURL: process.env.UI_BASE_URL || "http://127.0.0.1:4045",
+    baseURL: process.env.UI_BASE_URL || "http://127.0.0.1:4245",
     trace: "on-first-retry",
     screenshot: "only-on-failure",
     video: "retain-on-failure",

--- a/_includes/svg/q42-domain-language-v2026.svg
+++ b/_includes/svg/q42-domain-language-v2026.svg
@@ -30,6 +30,28 @@
     <symbol id="domain-language-icon-award" viewBox="0 0 384 512">
       <path d="M288 358.3C302 350.2 305.5 328.3 316.9 316.9S350.2 302 358.3 288C366.2 274.2 358.4 253.5 362.6 237.7C366.7 222.5 383.1 208.5 383.1 192S365.8 161.5 361.7 146.3C357.5 130.5 365.3 109.8 357.4 96C349.3 82 327.4 78.5 316 67.1S301.1 33.8 287.1 25.7C273.3 17.7 252.6 25.5 236.9 21.3C222.5 17.3 208.5 0 192 0S161.5 17.3 146.3 21.3C130.5 25.5 109.8 17.7 96 25.7C82 33.8 78.5 55.7 67.1 67.1S33.8 82 25.7 96C17.7 109.7 25.6 130.5 21.4 146.2C17.3 161.5 0 175.5 0 192S17.3 222.5 21.3 237.7C25.5 253.5 17.7 274.2 25.7 288C33.8 302 55.7 305.5 67.1 316.9S82 350.2 96 358.3C109.8 366.3 130.5 358.5 146.3 362.7C161.5 366.7 175.5 384 192 384S222.5 366.7 237.7 362.7C253.5 358.5 274.2 366.3 288 358.3ZM112 192C112 147.7 147.8 112 192 112S272 147.7 272 192S236.2 272 192 272S112 236.2 112 192ZM1.7 433.2C-1.5 441.4 0 450.7 5.6 457.5C11.3 464.2 20.1 467.4 28.7 465.6L73.9 456.6L95.3 498.8C99.5 507 107.6 512 116.7 512H117.7C127.2 511.6 135.4 505.9 138.9 497.1L172.5 415C118.8 410.4 70.5 386.9 34.3 351.1L1.7 433.2ZM349.6 351.1C313.5 386.9 265.2 410.4 211.4 415L245 497.1C248.6 505.9 256.7 511.6 266.2 512H267.3C276.4 512 284.5 507 288.7 498.9L310.1 456.6L355.3 465.6C363.9 467.4 372.8 464.2 378.4 457.5C384.1 450.7 385.5 441.4 382.3 433.2L349.6 351.1Z"/>
     </symbol>
+
+    <!--
+      One clip path per box: the accent bars are drawn flush with the box edge and
+      clipped to its outline, so every bar picks up the same 12px corner radius
+      instead of floating inside or poking out. Keep each rect in sync with the
+      box-surface rect of the same name.
+    -->
+    <clipPath id="domain-language-clip-dimension">
+      <rect x="370" y="120" width="160" height="80" rx="12"/>
+    </clipPath>
+    <clipPath id="domain-language-clip-approach">
+      <rect x="0.5" y="320" width="169" height="120" rx="12"/>
+    </clipPath>
+    <clipPath id="domain-language-clip-characteristic">
+      <rect x="350" y="315" width="200" height="130" rx="12"/>
+    </clipPath>
+    <clipPath id="domain-language-clip-requirement">
+      <rect x="690" y="120" width="190" height="130" rx="12"/>
+    </clipPath>
+    <clipPath id="domain-language-clip-standard">
+      <rect x="690" y="328.5" width="190" height="105" rx="12"/>
+    </clipPath>
   </defs>
 
   <g class="domain-language-svg__connectors" aria-hidden="true">
@@ -75,8 +97,9 @@
   <a href="{{ '/dimensions/' | prepend: site.baseurl }}" class="domain-language-link domain-language-link--box" aria-label="Quality dimensions — the top-level tags structuring all characteristics">
     <title>Explore the quality dimensions</title>
     <rect class="domain-language-svg__box-surface" x="370" y="120" width="160" height="80" rx="12" fill="#e4edec" stroke="#e2d6dd"/>
-    <rect x="367" y="124" width="10" height="72" rx="3" fill="#0077ad"/>
-    <use href="#domain-language-icon-tag" x="381" y="122" width="27" height="27" fill="#003366"/>
+    <rect class="domain-language-svg__box-accent" x="370" y="120" width="10" height="80"
+      fill="#0077ad" clip-path="url(#domain-language-clip-dimension)"/>
+    <use href="#domain-language-icon-tag" x="385" y="122" width="27" height="27" fill="#003366"/>
     <text x="450" y="143" text-anchor="middle" fill="#003366">
       <tspan x="450" class="domain-language-svg__box-detail">(top-level)</tspan>
       <tspan x="450" dy="27" class="domain-language-svg__box-title">Dimension</tspan>
@@ -134,8 +157,9 @@
   <a href="{{ '/approaches/' | prepend: site.baseurl }}" class="domain-language-link domain-language-link--box" aria-label="Approaches — patterns, practices, tactics and strategies">
     <title>Explore solution approaches</title>
     <rect class="domain-language-svg__box-surface" x="0.5" y="320" width="169" height="120" rx="12" fill="#eaf6e2" stroke="#e2d6dd"/>
-    <rect x="0" y="322" width="10" height="114" rx="3" fill="#92ef80"/>
-    <use href="#domain-language-icon-puzzle" x="14" y="322" width="30" height="30" fill="#1b5e20"/>
+    <rect class="domain-language-svg__box-accent" x="0.5" y="320" width="10" height="120"
+      fill="#92ef80" clip-path="url(#domain-language-clip-approach)"/>
+    <use href="#domain-language-icon-puzzle" x="16" y="322" width="30" height="30" fill="#1b5e20"/>
     <text x="85" y="371" text-anchor="middle" fill="#1b5e20">
       <tspan x="85" class="domain-language-svg__box-title">Approach</tspan>
       <tspan x="85" dy="22" class="domain-language-svg__box-detail">pattern, practice,</tspan>
@@ -147,7 +171,8 @@
   <a href="{{ '/qualities/' | prepend: site.baseurl }}" class="domain-language-link domain-language-link--box" aria-label="Quality characteristics — the full list of specific quality terms">
     <title>Explore quality characteristics</title>
     <rect class="domain-language-svg__box-surface" x="350" y="315" width="200" height="130" rx="12" fill="#d5eef2" stroke="#e2d6dd"/>
-    <rect x="349" y="324" width="10" height="114" rx="3" fill="#00b8f5"/>
+    <rect class="domain-language-svg__box-accent" x="350" y="315" width="10" height="130"
+      fill="#00b8f5" clip-path="url(#domain-language-clip-characteristic)"/>
     <use href="#domain-language-icon-gem" x="366" y="324" width="30" height="30" fill="#003366"/>
     <text x="450" y="340" text-anchor="middle" fill="#113040">
       <tspan x="450" class="domain-language-svg__box-detail">(specific)</tspan>
@@ -161,7 +186,8 @@
   <a href="{{ '/requirements/' | prepend: site.baseurl }}" class="domain-language-link domain-language-link--box" aria-label="Example requirements with metrics and acceptance criteria">
     <title>Explore example quality requirements</title>
     <rect class="domain-language-svg__box-surface" x="690" y="120" width="190" height="130" rx="12" fill="#f9ede9" stroke="#e2d6dd"/>
-    <rect x="690" y="128" width="12" height="114" rx="3" fill="#ffb3b3"/>
+    <rect class="domain-language-svg__box-accent" x="690" y="120" width="10" height="130"
+      fill="#ffb3b3" clip-path="url(#domain-language-clip-requirement)"/>
     <use href="#domain-language-icon-target" x="707" y="124" width="23" height="23" fill="#8b0000"/>
     <text x="785" y="161" text-anchor="middle" fill="#8b0000">
       <tspan x="785" class="domain-language-svg__requirement-title">Example</tspan>
@@ -175,7 +201,8 @@
   <a href="{{ '/standards/' | prepend: site.baseurl }}" class="domain-language-link domain-language-link--box" aria-label="Quality-related standards">
     <title>Explore quality standards</title>
     <rect class="domain-language-svg__box-surface" x="690" y="328.5" width="190" height="105" rx="12" fill="#f9f3e6" stroke="#e2d6dd"/>
-    <rect x="690" y="336.5" width="12" height="89" rx="3" fill="#ffc95c"/>
+    <rect class="domain-language-svg__box-accent" x="690" y="328.5" width="10" height="105"
+      fill="#ffc95c" clip-path="url(#domain-language-clip-standard)"/>
     <use href="#domain-language-icon-award" x="705" y="331.5" width="29" height="29" fill="#2c3e50"/>
     <text x="785" y="374" text-anchor="middle" fill="#113040">
       <tspan x="785" class="domain-language-svg__box-title">Standard</tspan>

--- a/_includes/svg/q42-domain-language-v2026.svg
+++ b/_includes/svg/q42-domain-language-v2026.svg
@@ -37,6 +37,9 @@
       instead of floating inside or poking out. Keep each rect in sync with the
       box-surface rect of the same name.
     -->
+    <clipPath id="domain-language-clip-quality">
+      <rect x="10" y="120" width="160" height="80" rx="12"/>
+    </clipPath>
     <clipPath id="domain-language-clip-dimension">
       <rect x="370" y="120" width="160" height="80" rx="12"/>
     </clipPath>
@@ -86,6 +89,8 @@
   <a href="{{ '/articles/what-is-quality' | prepend: site.baseurl }}" class="domain-language-link domain-language-link--box" aria-label="System- or product quality — what quality means">
     <title>Read the article: What is Quality?</title>
     <rect class="domain-language-svg__box-surface" x="10" y="120" width="160" height="80" rx="12" fill="#ece7e7" stroke="#e2d6dd"/>
+    <rect class="domain-language-svg__box-accent" x="10" y="120" width="10" height="80"
+      fill="#682d63" clip-path="url(#domain-language-clip-quality)"/>
     <text x="90" y="143" text-anchor="middle" class="domain-language-svg__system-title">
       <tspan x="90">System- or</tspan>
       <tspan x="90" dy="25">Product</tspan>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,14 +34,14 @@ services:
       - jekyll_site:/site/_site
       - jekyll_cache:/site/.jekyll-cache
       - sass_cache:/site/.sass-cache
-    # 4045 is this site's fixed dev port (see raw/port-assignment.md in
+    # 4245 is this site's fixed dev port (see raw/port-assignment.md in
     # meta.arc42.org). --port below hands the same number to Jekyll: its
     # "Server address:" banner reports the port it was told to bind, so a
     # host-side-only mapping would leave the banner naming the wrong port.
     ports:
-      - "4045:4045"
+      - "4245:4245"
     command: >
-      sh -c "bundle exec jekyll serve --incremental --watch --host 0.0.0.0 --port 4045 $${POLLING} --config _config.yml,_config_dev.yml"
+      sh -c "bundle exec jekyll serve --incremental --watch --host 0.0.0.0 --port 4245 $${POLLING} --config _config.yml,_config_dev.yml"
 
   playwright:
     build:
@@ -53,7 +53,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
-      UI_BASE_URL: http://host.docker.internal:4045
+      UI_BASE_URL: http://host.docker.internal:4245
     volumes:
       - .:/site
       - playwright_node_modules:/site/node_modules

--- a/tests/ui/https-redirect.spec.ts
+++ b/tests/ui/https-redirect.spec.ts
@@ -3,7 +3,7 @@ import { test, expect, request } from "@playwright/test";
 /**
  * PRODUCTION check: HTTP → HTTPS redirect.
  *
- * The Lighthouse suite audits the local dev server (http://jekyll:4045),
+ * The Lighthouse suite audits the local dev server (http://jekyll:4245),
  * which has no TLS listener — so Lighthouse's `redirects-http` audit can
  * never pass locally and is skipped there (see lighthouse.spec.ts). The
  * redirect itself is performed by GitHub Pages ("Enforce HTTPS"), i.e. by

--- a/tests/ui/lighthouse.spec.ts
+++ b/tests/ui/lighthouse.spec.ts
@@ -65,7 +65,7 @@ test.describe("Lighthouse Audits", () => {
           extends: "lighthouse:default",
           settings: {
             // Both HTTPS audits are environment artifacts here: the audit
-            // target is the local dev server (http://jekyll:4045), which has
+            // target is the local dev server (http://jekyll:4245), which has
             // no TLS listener, so neither "is HTTPS" nor "redirects to HTTPS"
             // can ever pass locally. The behaviour these audits want IS
             // asserted — against production, where the redirect actually


### PR DESCRIPTION
Fixes #519. Also carries the dev-port fix for #520, merged in from `fix/520-dev-port-42xx` (see #522) — without it the diagram cannot be opened in a browser and none of the UI tests can run.

## What was wrong

Every accent bar in the metamodel diagram (`_includes/svg/q42-domain-language-v2026.svg`) was an independent `<rect>` with hand-picked coordinates, none of them derived from the box they belong to:

| Box | bar x vs box x | vertical inset | width |
|---|---|---|---|
| Dimension | **−3** (outside the box) | 4 | 10 |
| Approach | **−0.5** | 2 | 10 |
| Quality Characteristic | **−1** | 9 top / 7 bottom | 10 |
| Example Requirement | 0 | 8 | **12** |
| Standard | 0 | 8 | **12** |
| System- or Product Quality | *no bar* | | |

Two visible defects fall out of that. Bars sitting at or left of the box edge poke out of the 12px rounded corners — worst on Dimension, which is what the issue screenshot circles. The two right-hand bars are inset far enough to read as detached pills floating inside their box. The widths don't match either.

## What this changes

Stop positioning bars by eye. Each bar is now drawn flush with its box — same `x`, same `y`, full box height, uniform 10px width — and clipped to a `clipPath` holding the box outline. The clip makes every bar inherit the box's 12px corner radius, so it reads as the left edge *of* the box rather than a shape sitting near it. One rule for all boxes, and geometry that can't drift again as long as each clip rect matches its `box-surface` rect (noted in a comment in the file).

The tag and puzzle icons move 4px / 2px right to keep an even gap to the now further-reaching bar.

Second commit adds the missing sixth bar: "System- or Product Quality" was the only box without one. It uses the brand violet `#682d63`, drawn and clipped exactly like the other five.

## Verification

- Rendered on the running dev server and screenshotted from Chromium via the repo's Playwright container — all six bars flush, corners correct.
- `tests/ui/how-to.spec.ts` passes (6/6), including the axe accessibility check on the figure.

## Also in this PR: the dev port fix (#520)

`4045` is on the WHATWG bad-port list as "lockd", enforced by both Chrome (`kRestrictedPorts` in `net/base/port_util.cc`) and Firefox (`gBadPortList` in `netwerk/base/nsIOService.cpp`, which also blocks 4190). No browser will connect to `http://localhost:4045`, so `make test` failed for everyone on `page.goto` with `ERR_UNSAFE_PORT`. CI never noticed because `wcag-refresh` runs its own Jekyll on 4000.

Moved to **4245**: same one-port-per-arc42-site scheme, block shifted to `42xx` which has no blocked ports in either browser, last two digits unchanged so meta.arc42.org's table maps `40NN → 42NN`. Touches `Makefile`, `docker-compose.yml`, `_docker/jekyll/Dockerfile`, `_docker/playwright/playwright.config.ts`, `AGENTS.md`, two test comments, and the README paragraph (which now records why the block is `42xx` and that 4045/4190 must never be assigned).

**Full Playwright suite passes on the merged branch: 62/62**, with no `--explicitly-allowed-ports` workaround.

#522 holds the same commit on its own branch. Merging this PR makes it redundant.


---

https://claude.ai/code/session_01AYDY4P4hJsSYY1x7H7dk6c
