### PR TITLE
build: move the dev port off the browser blocked list (4045 -> 4245)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 - Config: `_config.yml`, `Gemfile`, `docker-compose.yml`, `package.json`.
 
 ## Build, Test, and Development
-- `docker compose up`: builds the Jekyll site and serves on `http://localhost:4045/` — this site's fixed dev port, see `raw/port-assignment.md` in meta.arc42.org.
+- `docker compose up`: builds the Jekyll site and serves on `http://localhost:4245/` — this site's fixed dev port, see `raw/port-assignment.md` in meta.arc42.org.
 - `docker compose down`: stops stack so compose changes take effect on next start.
 - `npm run build`: generate graph data and bundle JS to `assets/js` once.
 - `npm run watch`: build and watch for JS changes.

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # just on the host side, so its "Server address:" startup banner names the real
 # port -- which is also why the Playwright container reaches the site at
 # http://jekyll:$(SITE_PORT) rather than at Jekyll's default 4000.
-SITE_PORT ?= 4045
+SITE_PORT ?= 4245
 
 .PHONY: help build clean dev down doctor diagnose test wcag-test wcag-test-strict lighthouse-test assets prettier-write
 

--- a/README.md
+++ b/README.md
@@ -107,18 +107,24 @@ make build
 make dev
 ```
 
-The site serves on http://localhost:4045. Content and front-matter changes
+The site serves on http://localhost:4245. Content and front-matter changes
 are picked up live; rebuild images only when `package-lock.json` or
 `Gemfile.lock` change.
 
-The port is fixed at **4045**, not Jekyll's default 4000, so this dev stack can
+The port is fixed at **4245**, not Jekyll's default 4000, so this dev stack can
 run alongside the other arc42 sites' dev servers without a clash — see
-`raw/port-assignment.md` in meta.arc42.org for the full assignment. Jekyll binds
-4045 inside the container as well as on the host, so its "Server address:"
-startup banner names the real port. Four places must stay in step: `SITE_PORT`
-in the `Makefile`, the mapping plus `--port` in `docker-compose.yml`, `CMD` in
-`_docker/jekyll/Dockerfile`, and the `UI_BASE_URL` the Playwright service uses
-to reach the site (`http://jekyll:4045`). The `wcag-refresh` GitHub workflow
+`raw/port-assignment.md` in meta.arc42.org for the full assignment. arc42 dev
+ports live in the `42xx` block because that whole range is free of the ports
+browsers refuse to connect to; the site's earlier port, 4045, was one of them
+("lockd" on the WHATWG bad-port list, enforced by Chrome and Firefox), which
+made the dev server unreachable and every Playwright spec fail with
+`ERR_UNSAFE_PORT`. Never assign 4045 or 4190. Jekyll binds 4245 inside the
+container as well as on the host, so its "Server address:" startup banner names
+the real port. Five places must stay in step: `SITE_PORT` in the `Makefile`, the
+mapping plus `--port` in `docker-compose.yml`, `CMD` in
+`_docker/jekyll/Dockerfile`, the `UI_BASE_URL` the Playwright service uses to
+reach the site (`http://jekyll:4245`), and the `baseURL` fallback in
+`_docker/playwright/playwright.config.ts`. The `wcag-refresh` GitHub workflow
 still uses 4000 — it runs its own Jekyll on a CI runner with no siblings around,
 so nothing there can clash.
 
@@ -127,7 +133,7 @@ so nothing there can clash.
 | Command                 | What it does                                                                                                                               |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `make build`            | Build Docker images. Slow path — runs `bundle install` and `npm ci` inside the images.                                                     |
-| `make dev`              | Start the prebuilt dev stack (esbuild watcher + Jekyll on port 4045).                                                                      |
+| `make dev`              | Start the prebuilt dev stack (esbuild watcher + Jekyll on port 4245).                                                                      |
 | `make doctor`           | Sanity-check the dev stack: Docker up, site reachable, key routes (including alias redirects) responding.                                  |
 | `make clean`            | Remove `_site/`.                                                                                                                           |
 | `make test`             | Run Playwright UI tests in Docker. Starts the stack first if needed.                                                                       |

--- a/_docker/jekyll/Dockerfile
+++ b/_docker/jekyll/Dockerfile
@@ -19,4 +19,4 @@ RUN chmod +x /usr/local/bin/jekyll-entrypoint
 WORKDIR /site
 
 ENTRYPOINT ["jekyll-entrypoint"]
-CMD ["bundle", "exec", "jekyll", "serve", "--incremental", "--watch", "--host", "0.0.0.0", "--port", "4045", "--force_polling"]
+CMD ["bundle", "exec", "jekyll", "serve", "--incremental", "--watch", "--host", "0.0.0.0", "--port", "4245", "--force_polling"]

--- a/_docker/playwright/playwright.config.ts
+++ b/_docker/playwright/playwright.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     ["html", { open: "never", outputFolder: path.join(repoRoot, "playwright-report") }],
   ],
   use: {
-    baseURL: process.env.UI_BASE_URL || "http://127.0.0.1:4045",
+    baseURL: process.env.UI_BASE_URL || "http://127.0.0.1:4245",
     trace: "on-first-retry",
     screenshot: "only-on-failure",
     video: "retain-on-failure",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,14 +34,14 @@ services:
       - jekyll_site:/site/_site
       - jekyll_cache:/site/.jekyll-cache
       - sass_cache:/site/.sass-cache
-    # 4045 is this site's fixed dev port (see raw/port-assignment.md in
+    # 4245 is this site's fixed dev port (see raw/port-assignment.md in
     # meta.arc42.org). --port below hands the same number to Jekyll: its
     # "Server address:" banner reports the port it was told to bind, so a
     # host-side-only mapping would leave the banner naming the wrong port.
     ports:
-      - "4045:4045"
+      - "4245:4245"
     command: >
-      sh -c "bundle exec jekyll serve --incremental --watch --host 0.0.0.0 --port 4045 $${POLLING} --config _config.yml,_config_dev.yml"
+      sh -c "bundle exec jekyll serve --incremental --watch --host 0.0.0.0 --port 4245 $${POLLING} --config _config.yml,_config_dev.yml"
 
   playwright:
     build:
@@ -53,7 +53,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
-      UI_BASE_URL: http://host.docker.internal:4045
+      UI_BASE_URL: http://host.docker.internal:4245
     volumes:
       - .:/site
       - playwright_node_modules:/site/node_modules

--- a/tests/ui/https-redirect.spec.ts
+++ b/tests/ui/https-redirect.spec.ts
@@ -3,7 +3,7 @@ import { test, expect, request } from "@playwright/test";
 /**
  * PRODUCTION check: HTTP → HTTPS redirect.
  *
- * The Lighthouse suite audits the local dev server (http://jekyll:4045),
+ * The Lighthouse suite audits the local dev server (http://jekyll:4245),
  * which has no TLS listener — so Lighthouse's `redirects-http` audit can
  * never pass locally and is skipped there (see lighthouse.spec.ts). The
  * redirect itself is performed by GitHub Pages ("Enforce HTTPS"), i.e. by

--- a/tests/ui/lighthouse.spec.ts
+++ b/tests/ui/lighthouse.spec.ts
@@ -65,7 +65,7 @@ test.describe("Lighthouse Audits", () => {
           extends: "lighthouse:default",
           settings: {
             // Both HTTPS audits are environment artifacts here: the audit
-            // target is the local dev server (http://jekyll:4045), which has
+            // target is the local dev server (http://jekyll:4245), which has
             // no TLS listener, so neither "is HTTPS" nor "redirects to HTTPS"
             // can ever pass locally. The behaviour these audits want IS
             // asserted — against production, where the redirect actually


### PR DESCRIPTION
Fixes #520.

## The problem

`4045` is on the WHATWG bad-port list as "lockd" (the NFS lock daemon), and both Chrome and Firefox enforce it:

- Chromium — `net/base/port_util.cc`, `kRestrictedPorts` contains `4045`.
- Firefox — `netwerk/base/nsIOService.cpp`, `gBadPortList` contains `4045` and `4190`.

So no browser will connect to `http://localhost:4045` — the request is refused before it reaches Jekyll. `make test` was broken for everyone: all Playwright specs failed on `page.goto` with

```
Error: page.goto: net::ERR_UNSAFE_PORT at http://host.docker.internal:4045/how-to-use-this-site/
```

CI never noticed, because `wcag-refresh` runs its own Jekyll on port 4000. Safari doesn't enforce the list, which is why the dev server appeared to work in some setups.

## The fix

Move to **4245**, keeping the one-fixed-port-per-arc42-site scheme but shifting the block to `42xx`, which contains no blocked ports in either browser. The last two digits are unchanged, so the assignment table in meta.arc42.org maps `40NN → 42NN` — no existing assignment has to be renegotiated.

Changed: `Makefile` (`SITE_PORT`), `docker-compose.yml` (mapping, `--port`, `UI_BASE_URL`), `_docker/jekyll/Dockerfile` (`CMD`), `_docker/playwright/playwright.config.ts` (`baseURL` fallback), `AGENTS.md`, and comments in two test files. The README paragraph now records why the block is `42xx`, that 4045 and 4190 must never be assigned, and lists all five places the port has to stay in step (it previously said four — it missed the Playwright config).

## Verification

- Rebuilt the Jekyll image, stack comes up on 4245, `make doctor` passes.
- **Full Playwright suite passes: 62/62**, with no `--explicitly-allowed-ports` workaround. On `main` the same suite cannot get past `page.goto`.

## Follow-ups (tracked in #520, outside this repo)

- meta.arc42.org `raw/port-assignment.md`: move the block to `42xx`, note that 4045 and 4190 are browser-blocked.
- Sibling arc42 sites: same prefix shift when convenient. They are only broken in browsers today if they drew 4045 or 4190.


---

https://claude.ai/code/session_01AYDY4P4hJsSYY1x7H7dk6c
