### PR TITLE
Fix alias row background width (#517) and bullet-list full stops (#518)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,7 @@ Link validator checks: quality→quality `related`, quality→tag, quality→sta
 
 - **JS**: ES Modules, include `.js` in imports, kebab-case for entry files, PascalCase for class files, Prettier-formatted (2 spaces, semicolons, 100 cols).
 - **Content**: kebab-case permalinks, alphabetical subdirectories, filename ≈ permalink.
+- **Bullet punctuation**: a list item that is a complete sentence ends with a full stop; a fragment (term, label, criterion, reference entry) does not. Whichever applies, **every item in the same list is punctuated the same way**. Two exceptions, both already in use: one sentence split across bullets keeps its commas and its closing full stop, and a stop belongs inside a closing quote only when the quoted material is itself a complete sentence.
 - **Commits**: imperative mood with area prefix — `content: add ISO-42010`, `graph: fix edges for missing node`, `build: bump esbuild`.
 - **Git staging**: stage files explicitly by name. Do not use `git add -A`, `git add .`, `git commit -am`, or globs.
 

--- a/_approaches/C/circuit-breaker.md
+++ b/_approaches/C/circuit-breaker.md
@@ -49,7 +49,7 @@ The circuit starts **Closed**. Once the failure rate or consecutive failure coun
 
 - **Chaos injection**: Use a tool (e.g., Chaos Monkey) to inject 100% latency or 500 errors into a dependency and verify the circuit trips to "Open" within the expected number of calls.
 - **Recovery check**: Verify that the circuit transitions to "Half-Open" and then "Closed" automatically once the dependency's health is restored.
-- **Fallback correctness**: Assert that the system returns the expected fallback response (e.g., cached data or a user-friendly message) while the circuit is "Open."
+- **Fallback correctness**: Assert that the system returns the expected fallback response (e.g., cached data or a user-friendly message) while the circuit is "Open".
 - **Metric validation**: Monitor state transitions and "Open" duration; the error rate for upstream callers should stay within the defined SLO even when the downstream service is down.
 
 ## Variants and Related Tactics

--- a/_articles/02-quality-models.md
+++ b/_articles/02-quality-models.md
@@ -96,7 +96,7 @@ Apart from being in wide use, these models really lack practical applicability, 
 I covered a few downsides in my [article on ISO-25010 shortcomings](/articles/iso-25010-shortcomings).
 To summarize:
 
-* Overly many terms, with a lot of overlap.
+* Overly many terms, with a lot of overlap
 * Critical qualities (e.g. safety, scalability, operational properties) missing from the official version
 * Despite proposing 30+ attributes, code- and architectural qualities are missing
 * No examples of how the ISO-model might be applied to real-world problems 

--- a/_articles/05-arc42-quality-model.md
+++ b/_articles/05-arc42-quality-model.md
@@ -101,7 +101,7 @@ Q42 regards development teams as first-class citizens:
 * `#reliable` in terms of "We can add now features or otherwise modify the systems, and can reliably predict the consequences of our changes. We can reliably fix bugs. We can reliably predict runtime behaviour."
 * `#flexible` in several dimensions, e.g. flexible module or component structure, flexible code that is easy to modify, flexible software and hardware infrastructure.
 * `#usable` in terms of understandable module structures, understandable code and data structures, understandable runtime behaviour.
-* `#suitable` in terms of appropriately "We can easily understand, test and modify code, and we can add new responsibilities and functions with appropriate risks".
+* `#suitable` in terms of appropriately "We can easily understand, test and modify code, and we can add new responsibilities and functions with appropriate risks."
 
 ### Summary
 The arc42 quality model has yet to prove its practical applicability, as it hit the _market_ only in January 2023.

--- a/_articles/06-quality-requirements.md
+++ b/_articles/06-quality-requirements.md
@@ -305,5 +305,5 @@ Try this pragmatic two-tier approach (we like to call it _Q42-quality-scenario_)
 
 ##### Changelog
 
-- Originally written December 2023.
-- revised March 2026
+- Originally written December 2023
+- Revised March 2026

--- a/_articles/07-iso-25010-update-2023.md
+++ b/_articles/07-iso-25010-update-2023.md
@@ -23,9 +23,9 @@ In our post on the [shortcomings of the ISO-25010:2011](/articles/iso-25010-shor
 
 Please observe some major differences:
 
-* _safety_ has been added (yeah, great!)
+* _safety_ has been added — yeah, great!
 * _usability_ has been renamed to _interaction capability_. Might be a matter of taste.
-* _portability_ has been renamed to _flexibility_. 
+* _portability_ has been renamed to _flexibility_.
 
 And, to quote the official website:
 

--- a/_pages/tag-efficient.md
+++ b/_pages/tag-efficient.md
@@ -7,7 +7,7 @@ permalink: /tag-efficient/
 
 <div class="arc42-help" markdown="1">
 
-* Resource-efficient, fast, low-footprint, low latency.
+* Resource-efficient, fast, low-footprint, low latency
 * Energy-, storage- and network efficient, having adequate capacity
 * Development-efficient, being easy to change (although that aspect may better be covered by [#flexible](/tag-flexible))
 * Time-to-market, how efficient new features can _go live_

--- a/_pages/tag-secure.md
+++ b/_pages/tag-secure.md
@@ -9,7 +9,7 @@ permalink: /tag-secure/
 
 <div class="arc42-help" markdown="1">
 
-- preventing unauthorized access to assets such as computers, networks, and data.
+- preventing unauthorized access to assets such as computers, networks, and data
 - maintaining confidentiality, integrity and availability of (sensitive) information
 
 </div><br>

--- a/_qualities/E/energy-proportionality.md
+++ b/_qualities/E/energy-proportionality.md
@@ -37,4 +37,4 @@ However, achieving good energy proportionality requires deliberate architectural
 ### Further reading
 
 * Sen, R. and Wood, D.A. (2017). [Energy-Proportional Computing: A New Definition](https://doi.org/10.1109/MC.2017.193). _Computer_, vol. 50, no. 8, pp. 26-33.
-* Microsoft Learn: [Sustainable Software Engineering — Energy Proportionality](https://learn.microsoft.com/en-us/learn/modules/sustainable-software-engineering-overview/7-energy-proportionality)
+* Microsoft Learn: [Sustainable Software Engineering — Energy Proportionality](https://learn.microsoft.com/en-us/learn/modules/sustainable-software-engineering-overview/7-energy-proportionality).

--- a/_qualities/R/readability.md
+++ b/_qualities/R/readability.md
@@ -7,7 +7,7 @@ permalink: /qualities/readability
 
 See also:
 
-* [code readability](/qualities/code-readability).
+* [code readability](/qualities/code-readability)
 * [legibility](/qualities/legibility)
 
 <hr>

--- a/_qualities/R/redundancy.md
+++ b/_qualities/R/redundancy.md
@@ -11,7 +11,7 @@ The term can be interpreted in two different directions:
 The goal (_required quality_) can be twofold: 
 
 * **free of redudancy** (or repetition), avoid duplication
-* **have (controlled)** redundancy or repetition, e.g. with redundant hardware or certain parts of systems to avoid downtime due to failures (e.g. due to hardware defects or component/service overload or similar).
+* **have (controlled)** redundancy or repetition, e.g. with redundant hardware or certain parts of systems to avoid downtime due to failures (e.g. due to hardware defects or component/service overload or similar)
 
   
 

--- a/_qualities/U/usability.md
+++ b/_qualities/U/usability.md
@@ -9,7 +9,7 @@ permalink: /qualities/usability
 
 See also 
 
-* [#usable](/tag-usable).
+* [#usable](/tag-usable)
 * [interaction-capability](/qualities/interaction-capability), a term that is used within the ISO-25010:2023 standard as a successor to "usability"
 
 

--- a/_sass/components/_index-explorer.scss
+++ b/_sass/components/_index-explorer.scss
@@ -168,10 +168,15 @@
   scroll-margin-top: 0.8rem;
 }
 
+// The reset here also has to undo `.site-content`'s prose measure: that block
+// caps every `ul` at 75ch for readability, which silently narrowed this list
+// to ~125px less than its bordered section. Only the tinted alias rows made it
+// visible -- their background stopped short of the section's right border.
 .index-explorer .ix-letter-list {
   list-style: none;
   margin: 0;
   padding: 0;
+  max-width: none;
 }
 
 // ─── Item grammar: title · meta · tags ─────────────────────────────────────

--- a/_standards/iso-iec-ieee/iso-iec-ieee-12207.md
+++ b/_standards/iso-iec-ieee/iso-iec-ieee-12207.md
@@ -14,7 +14,7 @@ ISO/IEC/IEEE 12207 establishes a comprehensive framework for software life cycle
 This standard 
 
 * defines processes, activities, and tasks that apply during the acquisition, development, operation, maintenance, and disposal of software systems,
-* serves as the foundation for software process improvement, project management, and quality assurance across the software lifecycle 
+* serves as the foundation for software process improvement, project management, and quality assurance across the software lifecycle,
 * provides a process architecture that supports various software development methodologies, from traditional waterfall to agile and iterative approaches, while ensuring systematic management of software quality attributes.
 
 ## Software Life Cycle Process Framework

--- a/_standards/iso/iso-27001.md
+++ b/_standards/iso/iso-27001.md
@@ -38,4 +38,4 @@ The specific controls are listed in Annex A and are further detailed in ISO/IEC 
 ## References
 
 - [ISO/IEC 27001:2022](https://www.iso.org/standard/82875.html)
-- ISO/IEC 27002 provides guidelines for the implementation of controls listed in ISO 27001 Annex A.
+- ISO/IEC 27002 — guidelines for the implementation of controls listed in ISO 27001 Annex A

--- a/_standards/iso/iso-8000.md
+++ b/_standards/iso/iso-8000.md
@@ -92,5 +92,5 @@ The ISO 8000 series is organized into numbered groups, each addressing a distinc
 
 - [ISO 8000 series — Data quality (ISO landing page)](https://www.iso.org/standard/81745.html)
 - [ISO 8000-8:2015 — Concepts and measuring](https://www.iso.org/standard/50798.html)
-- [ECCMA (Electronic Commerce Code Management Association)](https://eccma.org) — Authority for ISO 8000 master data certification.
-- [DAMA-DMBOK](/qualities/data-quality) — The Data Management Body of Knowledge provides a complementary industry framework for data quality dimensions.
+- [ECCMA (Electronic Commerce Code Management Association)](https://eccma.org) — authority for ISO 8000 master data certification
+- [DAMA-DMBOK](/qualities/data-quality) — the Data Management Body of Knowledge, a complementary industry framework for data quality dimensions

--- a/_standards/other/auic.md
+++ b/_standards/other/auic.md
@@ -45,5 +45,5 @@ It also indirectly influences other attributes like maintainability, portability
 ## References
 
 - [AIUC-1 (official): https://aiuc-1.com/](https://aiuc-1.com/)
-- related, and much more "official": [ISO-42001:2023](https://www.iso.org/standard/42001). Like most of the ISO documents, the details are hidden behind a paywall.
+- related, and much more "official": [ISO-42001:2023](https://www.iso.org/standard/42001) — like most of the ISO documents, the details are hidden behind a paywall
 


### PR DESCRIPTION
Fixes #517.

## Cause

`.site-content` applies a prose measure to text blocks:

```scss
p, ol, ul, dl, table, blockquote, kbd, pre, samp {
  margin: 1.5em 0;
  max-width: 75ch;
}
```

That cap reaches into component markup too. The A–Z explorer's row container is a `<ul class="ix-letter-list">`, so it inherited it: measured in Chromium at 1400px viewport, the list computes **825px (75ch) inside a 952px bordered section — 127px short of its right border**.

The component already resets `list-style`, `margin` and `padding` on that list for exactly this reason; `max-width` was simply missed.

Row backgrounds are transparent, so nothing showed it — until the tinted alias rows arrived. Their tint (and the row separators) stop a tenth of the way in from the section border, which is what the issue screenshot circles.

## Fix

Add `max-width: none` to the existing reset, with a comment recording where the inherited cap comes from. One line of CSS; no markup or JS changes.

## Verification

- DOM probe over `/qualities/`, `/approaches/`, `/requirements/`, `/standards/`, `/aliases/`: before the change, `UL.ix-letter-list` was the one element under `.index-explorer` computing a `max-width` (825px), on the three explorer pages. After: no element under `.index-explorer` computes a `max-width` on any of the five.
- Before/after screenshots of the Autonomicity alias row: tint and separators now reach the section's right border.
- Full Playwright suite: **62/62 passing**.
- Prettier clean.

---

## Also in this PR: full stops in bullet lists (#518)

Adopted the ordinary editorial rule, and wrote it into `CLAUDE.md` so it doesn't drift again:

> A list item that is a complete sentence takes a full stop; a fragment (term, label, criterion, reference entry) does not. Whichever applies, every item in the same list is punctuated the same way.

**Survey.** All 2936 bullets across the six content collections. 732 lists have two or more items; **19 mixed stopped and unstopped items**. 13 were real defects and are fixed here. The other 6 only looked mixed to a last-character test and were left alone:

- one sentence split across bullets, chained with commas and closed with a stop — `vulnerability`, ISO/IEC 25012, ISO/IEC/IEEE 12207, `03-iso-25010-shortcomings`
- `Braiterman et al.` — an abbreviation's period, not a sentence stop
- stops sitting inside a closing quote — `05-arc42-quality-model`

**What was deliberately not swept.** Full stops split by collection: approaches 85%, requirements 32%, qualities 31%, standards 27%, articles 21%, pages 13%. That is genre, not drift — approaches argue in prose sentences, while acceptance criteria and reference entries are fragments. Both are correct under the rule above, so the cross-collection difference was left as it is. Flattening it either way would mean rewriting ~1400 bullets against their grammar.

Two edits go slightly beyond punctuation, to keep an entry in the shape of the list around it: the ISO 27002 and DAMA-DMBOK reference entries are now annotations rather than sentences.

Unrelated typo spotted but **not** fixed, to keep this diff honest: `_articles/03-iso-25010-shortcomings.md:160` reads `become_faultlessness_` (missing space).

https://claude.ai/code/session_01AYDY4P4hJsSYY1x7H7dk6c
