### PR TITLE
style: restore the compact article listing on /articles/

### DIFF
--- a/_sass/_content.scss
+++ b/_sass/_content.scss
@@ -390,17 +390,41 @@
     }
   }
 
+  // Compact listing used by /articles/. article-header.html renders each
+  // entry with heading_level="h2" so the document outline stays sound, so
+  // these rules must not be h1-only -- they were, which left every entry
+  // with the full display-heading size and its 1.5em margins inside a
+  // bordered panel, i.e. a column of tall, near-empty boxes.
   #search-results {
     .article-wrapper {
-      margin: 1em 0;
+      margin: 0;
     }
     article header {
       margin-bottom: 0;
       .panel {
-        padding: 0;
-        background-color: $background-color;
-        h1 {
-          font-size: 1.3em;
+        padding: 0.8rem 0.2rem;
+        background-color: transparent;
+        border: none;
+        border-radius: 0;
+
+        h1,
+        h2 {
+          margin: 0;
+          font-size: 1.2rem;
+          line-height: 1.35;
+          letter-spacing: 0;
+
+          a {
+            display: inline-block;
+            text-decoration: none;
+
+            &:hover,
+            &:focus-visible {
+              text-decoration: underline;
+              text-underline-offset: 0.15em;
+            }
+          }
+
           a.tag {
             font-size: 0.7em;
           }

--- a/_sass/components/_panels.scss
+++ b/_sass/components/_panels.scss
@@ -77,11 +77,14 @@
   background-color: var(--article-background-color);
 }
 
-.panel.article-header h1,
-.panel.article-header h1 a,
-.site-content .panel.article-header h1,
-.site-content .panel.article-header h1 a {
-  color: var(--blue-text-color);
+// Articles are violet-coded across the site (violet hero accent,
+// --article-background-color); the listing title follows that, not the
+// blue that belongs to qualities.
+.panel.article-header :is(h1, h2),
+.panel.article-header :is(h1, h2) a,
+.site-content .panel.article-header :is(h1, h2),
+.site-content .panel.article-header :is(h1, h2) a {
+  color: var(--brand-violet-deep);
 }
 
 .category-header {

--- a/tests/ui/articles-index.spec.ts
+++ b/tests/ui/articles-index.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "@playwright/test";
+
+// The listing renders each entry as h2 (heading_level="h2" in
+// article-header.html) so the document outline stays sound. The compact
+// styles used to match h1 only, which left every entry as a display-size
+// heading with 1.5em margins inside a bordered panel -- a column of tall,
+// near-empty boxes.
+test("article listing entries stay compact", async ({ page }) => {
+  await page.goto("/articles/");
+
+  const entries = page.locator("#search-results .article-wrapper");
+  const count = await entries.count();
+  expect(count).toBeGreaterThan(5);
+
+  for (let i = 0; i < count; i += 1) {
+    const entry = entries.nth(i);
+    const title = entry.locator(".panel.article-header :is(h1, h2)");
+    await expect(title).toBeVisible();
+
+    const [entryHeight, fontSize] = await Promise.all([
+      entry.evaluate((el) => el.getBoundingClientRect().height),
+      title.evaluate((el) => parseFloat(getComputedStyle(el).fontSize)),
+    ]);
+
+    // A single-line title in a compact row, not a display heading in a box.
+    expect(entryHeight).toBeLessThan(90);
+    expect(fontSize).toBeLessThan(24);
+  }
+});
+
+test("article listing titles link to their article", async ({ page }) => {
+  await page.goto("/articles/");
+
+  const links = page.locator("#search-results .panel.article-header a.post-link");
+  const hrefs = await links.evaluateAll((elements) =>
+    elements.map((element) => element.getAttribute("href")),
+  );
+
+  expect(hrefs.length).toBeGreaterThan(5);
+  expect(hrefs.every((href) => href?.startsWith("/articles/"))).toBe(true);
+});


### PR DESCRIPTION
Closes #525.

## Problem

Every entry on <https://quality.arc42.org/articles/> rendered as a tall, near-empty bordered box holding nothing but the title. Reported by Sophie (Nien-chun Yin), REWE Group.

The compact-listing rules under `#search-results` in `_sass/_content.scss`, and the title-colour rule in `_sass/components/_panels.scss`, only matched `h1`. But `_includes/article-header.html` renders listing entries as `h2` so the document outline stays sound — an earlier accessibility fix that the CSS was never updated for. With no rule matching, each title fell back to the display heading size and its `1.5em` margins, inside a `.panel` whose 1px border stops those margins collapsing.

## Change

- Both rule sets are heading-level agnostic now (`h1, h2` / `:is(h1, h2)`).
- The listing panel drops its border and background — the `<hr>` separators already divide the rows, so the double lines are gone.
- Even vertical rhythm per row, plus a hover/focus underline on the title link.
- Titles use the article violet (`--brand-violet-deep`) rather than the blue that belongs to qualities, matching the violet hero directly above them.

The page went from ~3900px to ~2400px tall; the 10 articles now fit on one screen.

## Before / after

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/arc42/quality.arc42.org-site/27013a0b98eed926274b538fe2189e6d5be96122/TODO/screenshots/2026-09-sophie-website-bugs/fixed/525-before.png" width="420"> | <img src="https://raw.githubusercontent.com/arc42/quality.arc42.org-site/27013a0b98eed926274b538fe2189e6d5be96122/TODO/screenshots/2026-09-sophie-website-bugs/fixed/525-after.png" width="420"> |

Mobile (390px):

<img src="https://raw.githubusercontent.com/arc42/quality.arc42.org-site/27013a0b98eed926274b538fe2189e6d5be96122/TODO/screenshots/2026-09-sophie-website-bugs/fixed/525-after-mobile.png" width="260">

## Testing

- `tests/ui/articles-index.spec.ts` added: asserts rendered row height and title size rather than the selector, so the same class of regression (markup changes heading level, CSS silently stops matching) fails the suite. Verified it fails against the pre-fix CSS (row height 126px vs. the 90px bound).
- `npm run test:ui` — 64 passed.
- `npm run test:css:rules`, `prettier --check` on the touched files, `npm run test:links` — all clean.
