### PR TITLE
graph: restore the radial layout for dimension nodes

### DIFF
--- a/src/graphs/Graph.js
+++ b/src/graphs/Graph.js
@@ -246,9 +246,13 @@ export class Graph {
   }
 
   _positionPropertyNodes(rootId, levelRadius) {
-    const propertyNodes = this.graph
-      .inNeighbors(rootId)
-      .filter((n) => this.graph.getNodeAttribute(n, "qualityType") === NODE_TYPES.PROPERTY);
+    // The nine top-level nodes are typed "dimension"; "property" is the legacy
+    // spelling. Both must be accepted -- an empty result here skips the entire
+    // radial layout, leaving every node stacked on one point.
+    const propertyNodes = this.graph.inNeighbors(rootId).filter((n) => {
+      const type = this.graph.getNodeAttribute(n, "qualityType");
+      return type === NODE_TYPES.DIMENSION || type === NODE_TYPES.PROPERTY;
+    });
 
     if (propertyNodes.length === 0) return [];
 

--- a/tests/ui/graph-initial-layout.spec.ts
+++ b/tests/ui/graph-initial-layout.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * The radial layout must place every node before the force simulation runs.
+ *
+ * Blocking requestAnimationFrame stops d3-timer, so d3-force never ticks and
+ * what we measure is purely the initial layout. Without it, a broken layout is
+ * invisible in a test: the simulation eventually pushes the pile apart, and
+ * only real users on a slow or backgrounded tab see the stack of labels.
+ *
+ * Positions live on the data bound to the hit-circles; the SVG x/y attributes
+ * are written by the tick handler, which cannot run here.
+ */
+test("initial graph layout spreads nodes before the simulation ticks", async ({ page }) => {
+  await page.addInitScript(() => {
+    // d3-timer captures requestAnimationFrame at module load, so stub it early.
+    window.requestAnimationFrame = () => 0;
+  });
+
+  await page.goto("/full-quality-graph");
+  await expect(page.locator("#full-q-graph-container svg .nodes circle").first()).toBeAttached();
+
+  const layout = await page.evaluate(() => {
+    const circles = [
+      ...document.querySelectorAll("#full-q-graph-container svg .nodes circle"),
+    ] as (SVGCircleElement & {
+      __data__: { id: string; qualityType?: string; x: number; y: number };
+    })[];
+    const nodes = circles.map((c) => c.__data__);
+    const distinct = new Set(nodes.map((n) => `${Math.round(n.x)},${Math.round(n.y)}`));
+    const dimensions = nodes.filter((n) => n.qualityType === "dimension");
+    return {
+      total: nodes.length,
+      distinctPositions: distinct.size,
+      dimensionCount: dimensions.length,
+      distinctDimensionPositions: new Set(
+        dimensions.map((n) => `${Math.round(n.x)},${Math.round(n.y)}`),
+      ).size,
+      unplaced: nodes.filter((n) => !Number.isFinite(n.x) || !Number.isFinite(n.y)).length,
+    };
+  });
+
+  expect(layout.total).toBeGreaterThan(50);
+  expect(layout.unplaced).toBe(0);
+
+  // The nine dimension nodes ring the root, so each sits on its own spot.
+  expect(layout.dimensionCount).toBeGreaterThan(0);
+  expect(layout.distinctDimensionPositions).toBe(layout.dimensionCount);
+
+  // Guard the whole graph against collapsing onto one point.
+  expect(layout.distinctPositions).toBeGreaterThan(layout.total / 2);
+});


### PR DESCRIPTION
Closes #533

## The bug

`_positionPropertyNodes()` filtered the root's neighbours by the legacy `"property"` type, but the generated data types the nine top-level nodes as `"dimension"`. It matched nothing, returned `[]`, and short-circuited the whole of `applyEnhancedRadialLayout()` — so only the root node ever received `x`/`y`, and all 451 nodes entered the render stacked on one point at the container centre.

The initial view was then left to the force simulation untangling a coincident pile. Users on a backgrounded, throttled or slow tab saw the labels heaped in one spot with bare nodes. Clicking **Filter** appeared to fix it because that path uses `applyFilterFocusedLayout()`, which places nodes itself, and then restarts the simulation at `alpha(1)`.

Broken since the property → dimension rename; every other consumer was updated to `isProperty(d) || isDimension(d)`, this one was missed.

## The fix

One filter, accepting both spellings, consistent with how the renderer treats these nodes everywhere else.

## The test

`tests/ui/graph-initial-layout.spec.ts` stubs `requestAnimationFrame` before the bundle loads, so d3-timer never fires and d3-force never ticks. What it measures is purely the initial layout. Without that, the defect is untestable: the simulation spreads the pile within a second and any assertion made after load passes either way.

It reads positions from the data bound to the hit-circles, since the SVG `x`/`y` attributes are written by the tick handler, which cannot run.

## Verified

- Test fails on the old code (9 dimension nodes sharing 1 position), passes on the fix.
- Full Playwright suite: **68 passed**.
- Confirmed visually: root centred, nine dimension nodes ringed around it, qualities spread out.

## Related, deliberately not in this PR

`FullGraph.js:683,687` and `792,793` carry the same type drift — both test `"property"` only, both under comments that say "collect dimensions". Those branches are dead, so standard-selection highlighting silently misses the dimension nodes it means to include. Tracked separately.

