### PR TITLE
graph: light the dimensions behind a selected standard

### DIFF
--- a/src/graphs/FullGraph.js
+++ b/src/graphs/FullGraph.js
@@ -4,7 +4,7 @@
  */
 import { Graph } from "./Graph";
 import { MAX_FILTER_TERMS } from "./constants";
-import { isProperty, isRootId, isStandard } from "./nodeUtils";
+import { isDimension, isProperty, isRootId, isStandard } from "./nodeUtils";
 
 export class FullGraph extends Graph {
   #filterTypeState = {
@@ -677,14 +677,16 @@ export class FullGraph extends Graph {
               link.source.connectedHighlighted = true;
             }
           });
-          // Then collect dimensions 2-hop via qualities
+          // Then collect dimensions 2-hop via qualities. Top-level nodes are
+          // typed "dimension"; "property" is the legacy spelling.
+          const isDim = (n) => isDimension(n) || isProperty(n);
           const qualLookup = new Set(qualities);
           this.renderer.links.each(function (link) {
-            if (qualLookup.has(link.source.id) && isProperty(link.target)) {
+            if (qualLookup.has(link.source.id) && isDim(link.target)) {
               props.add(link.target.id);
               link.target.connectedHighlighted = true;
             }
-            if (qualLookup.has(link.target.id) && isProperty(link.source)) {
+            if (qualLookup.has(link.target.id) && isDim(link.source)) {
               props.add(link.source.id);
               link.source.connectedHighlighted = true;
             }
@@ -783,14 +785,16 @@ export class FullGraph extends Graph {
     });
 
     const qualLookup = new Set(connectedQuals);
+    // Top-level nodes are typed "dimension"; "property" is the legacy spelling.
+    const isDimType = (t) => t === "dimension" || t === "property";
     // Second pass: find dimensions and requirements attached to those qualities
     this.renderer.links.each(function (link) {
       const sId = getId(link.source);
       const tId = getId(link.target);
       const sType = endpointType(link.source);
       const tType = endpointType(link.target);
-      if (qualLookup.has(sId) && tType === "property") props.add(tId);
-      if (qualLookup.has(tId) && sType === "property") props.add(sId);
+      if (qualLookup.has(sId) && isDimType(tType)) props.add(tId);
+      if (qualLookup.has(tId) && isDimType(sType)) props.add(sId);
       if (qualLookup.has(sId) && tType === "requirement") reqs.add(tId);
       if (qualLookup.has(tId) && sType === "requirement") reqs.add(sId);
     });

--- a/tests/ui/graph-standard-selection.spec.ts
+++ b/tests/ui/graph-standard-selection.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Selecting a standard dims everything unrelated, but the dimensions behind the
+ * standard's qualities are meant to stay lit: the graph reads standard ->
+ * qualities -> dimensions. While a standard is selected the renderer hides
+ * dimension nodes that are dimmed, so an empty connected set makes all nine of
+ * them disappear instead of just the unrelated ones.
+ *
+ * ISO 5055 reaches three of the nine dimensions, which pins both halves of the
+ * behaviour: the related ones stay lit, the other six still dim.
+ *
+ * Node state lives on the data bound to the hit-circles, since the nodes
+ * themselves are painted on canvas.
+ */
+test("selecting a standard keeps the dimensions of its qualities lit", async ({ page }) => {
+  await page.goto("/full-quality-graph?showStandards=true&selectedStandard=iso5055");
+
+  const dimensions = async () =>
+    await page.evaluate(() => {
+      const circles = [
+        ...document.querySelectorAll("#full-q-graph-container svg .nodes circle"),
+      ] as (SVGCircleElement & {
+        __data__: { id: string; qualityType?: string; _dimmed?: boolean };
+      })[];
+      const nodes = circles
+        .map((c) => c.__data__)
+        .filter((d) => d.qualityType === "dimension" || d.qualityType === "property");
+      return {
+        total: nodes.length,
+        lit: nodes
+          .filter((d) => !d._dimmed)
+          .map((d) => d.id)
+          .sort(),
+      };
+    });
+
+  // The selection is applied once the render settles, so poll rather than race it.
+  await expect
+    .poll(async () => (await dimensions()).lit.join(","), { timeout: 15000 })
+    .toBe("maintainable,reliable,secure");
+
+  expect((await dimensions()).total).toBe(9);
+});


### PR DESCRIPTION
Closes #535 — the second half of the type drift found while diagnosing #533 (PR #534).

## The bug

Two two-hop lookups in `FullGraph.js` tested endpoints against the legacy `"property"` type, while their own comments said they were collecting *dimensions*:

- the standard-hover branch in `registerDefaultEventHandlers()`
- `_collectConnectedForStandard()`

The generated data types those nodes `"dimension"`, so both matched nothing and the `props` set was always empty.

Because `GraphRenderer` hides dimension nodes that are dimmed under an active standard selection (`_hideIfDimmedPropertyUnderStd`), an empty set meant **all nine dimension nodes disappeared** whenever a standard was selected.

## Repaired, not deleted

These read as dead branches, but deleting them would drop the intended `standard → qualities → dimensions` reading and strand the renderer code that exists only to serve it — `_hideIfDimmedPropertyUnderStd` and the standard branch of `_edgeShouldShowDespiteRoot` both already handle `isProperty(d) || isDimension(d)`. So the conditions are fixed the same way, rather than removed.

## Verified

`?showStandards=true&selectedStandard=iso5055`

| | dimensions lit |
|---|---|
| before | *(none — all nine hidden)* |
| after | `maintainable`, `reliable`, `secure` |

Those are exactly the three dimensions ISO/IEC 5055's qualities belong to, so the test pins both halves: the related ones stay lit, the other six still dim. Confirmed failing on the unfixed bundle and passing on the fix.

Full Playwright suite: **68 passed**.

## Note on ordering

Independent of #534 — different file, no conflict — so the two can merge in either order.

https://claude.ai/code/session_016rYo4HkrZDUhkGPQg7hfjT